### PR TITLE
Terrain smoothing brush and height fixes

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
@@ -185,7 +185,7 @@ public class Terrain implements RenderableProvider, Disposable {
             ray.getEndPoint(out, curDistance);
 
             boolean u = isUnderTerrain(out);
-            if (u != isUnder || rounds == 10000) {
+            if (u != isUnder || rounds == 20000) {
                 return out;
             }
             curDistance += u ? -0.1f : 0.1f;
@@ -329,7 +329,7 @@ public class Terrain implements RenderableProvider, Disposable {
     }
 
     public boolean isUnderTerrain(Vector3 worldCoords) {
-        // Factor in world position as well get getPosition.
+        // Factor in world height position as well via getPosition.
         float terrainHeight = getHeightAtWorldCoord(worldCoords.x, worldCoords.z) + getPosition(tmp).y;
         return terrainHeight > worldCoords.y;
     }

--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
@@ -54,6 +54,7 @@ public class Terrain implements RenderableProvider, Disposable {
     private static final Vector3 c01 = new Vector3();
     private static final Vector3 c10 = new Vector3();
     private static final Vector3 c11 = new Vector3();
+    private static final Vector3 tmp = new Vector3();
 
     public Matrix4 transform;
     public float[] heightData;
@@ -328,7 +329,8 @@ public class Terrain implements RenderableProvider, Disposable {
     }
 
     public boolean isUnderTerrain(Vector3 worldCoords) {
-        float terrainHeight = getHeightAtWorldCoord(worldCoords.x, worldCoords.z);
+        // Factor in world position as well get getPosition.
+        float terrainHeight = getHeightAtWorldCoord(worldCoords.x, worldCoords.z) + getPosition(tmp).y;
         return terrainHeight > worldCoords.y;
     }
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
@@ -55,6 +55,7 @@ public class Terrain implements RenderableProvider, Disposable {
     private static final Vector3 c10 = new Vector3();
     private static final Vector3 c11 = new Vector3();
     private static final Vector3 tmp = new Vector3();
+    private static final Vector2 tmpV2 = new Vector2();
 
     public Matrix4 transform;
     public float[] heightData;
@@ -165,11 +166,11 @@ public class Terrain implements RenderableProvider, Disposable {
         // we are in upper left triangle of the square
         if (xCoord <= (1 - zCoord)) {
             c00.set(0, heightData[gridZ * vertexResolution + gridX], 0);
-            return MathUtils.barryCentric(c00, c10, c01, new Vector2(zCoord, xCoord));
+            return MathUtils.barryCentric(c00, c10, c01, tmpV2.set(zCoord, xCoord));
         }
         // bottom right triangle
         c11.set(1, heightData[(gridZ + 1) * vertexResolution + gridX + 1], 1);
-        return MathUtils.barryCentric(c10, c11, c01, new Vector2(zCoord, xCoord));
+        return MathUtils.barryCentric(c10, c11, c01, tmpV2.set(zCoord, xCoord));
     }
 
     public Vector3 getRayIntersection(Vector3 out, Ray ray) {
@@ -267,7 +268,7 @@ public class Terrain implements RenderableProvider, Disposable {
      * surrounding vertices
      */
     private MeshPartBuilder.VertexInfo calculateNormalAt(MeshPartBuilder.VertexInfo out, int x, int y) {
-        out.normal.set(getNormalAt(x, y));
+        getNormalAt(out.normal, x, y);
         return out;
     }
 
@@ -276,7 +277,7 @@ public class Terrain implements RenderableProvider, Disposable {
      * position in terrain coordinates and returns normal at that point. If
      * point doesn't belong to terrain -- it returns default
      * <code>Vector.Y<code> normal.
-     * 
+     *
      * @param worldX
      *            the x coord in world
      * @param worldZ
@@ -284,7 +285,7 @@ public class Terrain implements RenderableProvider, Disposable {
      * @return normal at that point. If point doesn't belong to terrain -- it
      *         returns default <code>Vector.Y<code> normal.
      */
-    public Vector3 getNormalAtWordCoordinate(float worldX, float worldZ) {
+    public Vector3 getNormalAtWordCoordinate(Vector3 out, float worldX, float worldZ) {
         transform.getTranslation(c00);
         float terrainX = worldX - c00.x;
         float terrainZ = worldZ - c00.z;
@@ -297,20 +298,21 @@ public class Terrain implements RenderableProvider, Disposable {
             return Vector3.Y.cpy();
         }
 
-        return getNormalAt(gridX, gridZ);
+        return getNormalAt(out, gridX, gridZ);
     }
 
     /**
      * Get Normal at x,y point of terrain
-     * 
+     *
+     * @param out
+     *            Output vector
      * @param x
      *            the x coord on terrain
      * @param y
      *            the y coord on terrain( actual z)
      * @return the normal at the point of terrain
      */
-    public Vector3 getNormalAt(int x, int y) {
-        Vector3 out = new Vector3();
+    public Vector3 getNormalAt(Vector3 out, int x, int y) {
         // handle edges of terrain
         int xP1 = (x + 1 >= vertexResolution) ? vertexResolution - 1 : x + 1;
         int yP1 = (y + 1 >= vertexResolution) ? vertexResolution - 1 : y + 1;

--- a/editor/src/main/com/mbrlabs/mundus/editor/input/FreeCamController.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/input/FreeCamController.kt
@@ -108,6 +108,7 @@ class FreeCamController : InputAdapter() {
     }
 
     override fun scrolled(amountX: Float, amountY: Float): Boolean {
+        // If using combo key, do not consume event
         if (Gdx.input.isKeyPressed(Input.Keys.CONTROL_LEFT) || Gdx.input.isKeyPressed(Input.Keys.CONTROL_RIGHT)) return false
 
         tmp.set(camera!!.direction).nor().scl(-amountY * zoomAmount)

--- a/editor/src/main/com/mbrlabs/mundus/editor/input/FreeCamController.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/input/FreeCamController.kt
@@ -47,7 +47,7 @@ class FreeCamController : InputAdapter() {
     private var zoomAmount = SPEED_01
     private var degreesPerPixel = 0.5f
     private val tmp = Vector3()
-    private var pan = true;
+    private var pan = true
 
     fun setCamera(camera: Camera) {
         this.camera = camera
@@ -108,6 +108,8 @@ class FreeCamController : InputAdapter() {
     }
 
     override fun scrolled(amountX: Float, amountY: Float): Boolean {
+        if (Gdx.input.isKeyPressed(Input.Keys.CONTROL_LEFT) || Gdx.input.isKeyPressed(Input.Keys.CONTROL_RIGHT)) return false
+
         tmp.set(camera!!.direction).nor().scl(-amountY * zoomAmount)
         camera!!.position.add(tmp)
         return true

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainComponentWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainComponentWidget.kt
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.editor.ui.modules.inspector.components.terrain
 
+import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.tabbedpane.Tab
 import com.kotcrab.vis.ui.widget.tabbedpane.TabbedPane
@@ -37,6 +38,7 @@ class TerrainComponentWidget(terrainComponent: TerrainComponent) :
 
     private val raiseLowerTab = TerrainUpDownTab(this)
     private val flattenTab = TerrainFlattenTab(this)
+    private val smoothTab = TerrainSmoothTab(this)
     private val paintTab = TerrainPaintTab(this)
     private val genTab = TerrainGenTab(this)
     private val settingsTab = TerrainSettingsTab(this)
@@ -46,11 +48,13 @@ class TerrainComponentWidget(terrainComponent: TerrainComponent) :
 
         tabbedPane.add(raiseLowerTab)
         tabbedPane.add(flattenTab)
+        tabbedPane.add(smoothTab)
         tabbedPane.add(paintTab)
         tabbedPane.add(genTab)
         tabbedPane.add(settingsTab)
 
         collapsibleContent.add(tabbedPane.table).growX().row()
+        collapsibleContent.add(VisLabel("Use CTRL+Scroll Wheel to adjust brush size")).center().padBottom(4f).row()
         collapsibleContent.add(tabContainer).expand().fill().row()
         tabbedPane.switchTab(0)
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainSmoothTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainSmoothTab.kt
@@ -1,0 +1,33 @@
+package com.mbrlabs.mundus.editor.ui.modules.inspector.components.terrain
+
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.utils.Align
+import com.kotcrab.vis.ui.widget.VisTable
+import com.kotcrab.vis.ui.widget.tabbedpane.Tab
+import com.mbrlabs.mundus.editor.tools.brushes.TerrainBrush
+
+/**
+ * @author JamesTKhan
+ * @version July 17, 2022
+ */
+class TerrainSmoothTab(parent: TerrainComponentWidget) : Tab(false, false) {
+
+    private val table = VisTable()
+    private val brushGrid: TerrainBrushGrid
+
+    init {
+        table.align(Align.left)
+
+        brushGrid = TerrainBrushGrid(parent, TerrainBrush.BrushMode.SMOOTH)
+        table.add(brushGrid).expand().fill().row()
+    }
+
+    override fun getTabTitle(): String {
+        return "Smooth"
+    }
+
+    override fun getContentTable(): Table {
+        return table
+    }
+
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/utils/TerrainUtils.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/utils/TerrainUtils.kt
@@ -62,7 +62,7 @@ fun getRayIntersectionAndUp(terrains: Array<TerrainAsset>, ray: Ray): VertexInfo
         val terr = terrain.terrain
         terr.getRayIntersection(tempVI.position, ray)
         if (terr.isOnTerrain(tempVI.position.x, tempVI.position.z)) {
-            tempVI.normal.set(terr.getNormalAtWordCoordinate(tempVI.position.x, tempVI.position.z))
+            terr.getNormalAtWordCoordinate(tempVI.normal, tempVI.position.x, tempVI.position.z)
             return tempVI
         }
     }


### PR DESCRIPTION
Adds a new Terrain Brush for smoothing based on average heights of vertices within the brush radius. Also fixes the following issues

1. Terrain becomes un-editable by any brush when terrains global height is not zero. 
2. isUnderTerrain method did not factor in world height
3. Cleaned up terrain code that was instantiating new Vectors in looped methods
4. Paint brush radius can be changed now using CTRL+Scroll wheel

https://user-images.githubusercontent.com/28971753/179386694-ac6e30ca-1375-45c0-90f5-ce482226b1cc.mp4
