### PR TITLE
Add multi-texture import, drag and drop support

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
@@ -28,6 +28,7 @@ import com.mbrlabs.mundus.commons.utils.ShaderUtils
 import com.mbrlabs.mundus.editor.core.project.ProjectContext
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.core.registry.Registry
+import com.mbrlabs.mundus.editor.events.FilesDroppedEvent
 import com.mbrlabs.mundus.editor.events.FullScreenEvent
 import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
 import com.mbrlabs.mundus.editor.events.SceneChangedEvent
@@ -191,6 +192,10 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
 
     override fun pause() {}
     override fun resume() {}
+
+    override fun filesDropped(files: Array<out String>?) {
+        Mundus.postEvent(FilesDroppedEvent(files))
+    }
 
     override fun dispose() {
         Mundus.dispose()

--- a/editor/src/main/com/mbrlabs/mundus/editor/events/FilesDroppedEvent.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/events/FilesDroppedEvent.kt
@@ -1,0 +1,15 @@
+package com.mbrlabs.mundus.editor.events
+
+/**
+ * Event which is posted when files are dropped from an operating system into the mundus window.
+ *
+ * @author JamesTKhan
+ * @version July 18, 2022
+ */
+class FilesDroppedEvent(val files: Array<out String>?) {
+
+    interface FilesDroppedListener {
+        @Subscribe
+        fun onFilesDropped(event: FilesDroppedEvent)
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/BaseDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/BaseDialog.kt
@@ -16,13 +16,27 @@
 
 package com.mbrlabs.mundus.editor.ui.modules.dialogs
 
+import com.badlogic.gdx.scenes.scene2d.Stage
 import com.kotcrab.vis.ui.widget.VisDialog
 
 /**
+ * Base dialog to extend from. Tracks if it is currently open or not.
+ *
  * @author Marcus Brummer
  * @version 25-11-2015
  */
 open class BaseDialog(title: String) : VisDialog(title) {
+    protected var dialogOpen = false
+
+    override fun show(stage: Stage?): VisDialog {
+        dialogOpen = true
+        return super.show(stage)
+    }
+
+    override fun close() {
+        super.close()
+        dialogOpen = false
+    }
 
     init {
         addCloseButton()

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/SkyboxDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/SkyboxDialog.kt
@@ -22,6 +22,7 @@ import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
+import com.badlogic.gdx.utils.Array
 import com.kotcrab.vis.ui.util.FloatDigitsOnlyFilter
 import com.kotcrab.vis.ui.util.dialog.Dialogs
 import com.kotcrab.vis.ui.widget.VisCheckBox
@@ -44,6 +45,7 @@ import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.shader.Shaders
 import com.mbrlabs.mundus.editor.ui.widgets.ImageChooserField
 import com.mbrlabs.mundus.editor.utils.createDefaultSkybox
+import java.util.HashMap
 
 /**
  * @author Marcus Brummer
@@ -57,12 +59,12 @@ class SkyboxDialog : BaseDialog("Skybox"), ProjectChangedEvent.ProjectChangedLis
     private lateinit var rotateEnabled: VisCheckBox
     private var rotateSpeed = VisTextField()
 
-    private val positiveX: ImageChooserField = ImageChooserField(100, this)
-    private var negativeX: ImageChooserField = ImageChooserField(100, this)
-    private var positiveY: ImageChooserField = ImageChooserField(100, this)
-    private var negativeY: ImageChooserField = ImageChooserField(100, this)
-    private var positiveZ: ImageChooserField = ImageChooserField(100, this)
-    private var negativeZ: ImageChooserField = ImageChooserField(100, this)
+    private val positiveX: ImageChooserField = ImageChooserField(100, false, this)
+    private var negativeX: ImageChooserField = ImageChooserField(100, false, this)
+    private var positiveY: ImageChooserField = ImageChooserField(100, false, this)
+    private var negativeY: ImageChooserField = ImageChooserField(100, false, this)
+    private var positiveZ: ImageChooserField = ImageChooserField(100, false, this)
+    private var negativeZ: ImageChooserField = ImageChooserField(100, false, this)
 
     private var createBtn = VisTextButton("Create skybox")
     private var defaultBtn = VisTextButton("Create default skybox")
@@ -375,6 +377,13 @@ class SkyboxDialog : BaseDialog("Skybox"), ProjectChangedEvent.ProjectChangedLis
 
     override fun onImageChosen() {
         validateFields()
+    }
+
+    override fun onImagesChosen(
+        images: Array<FileHandle>?,
+        failedFiles: HashMap<FileHandle, String>
+    ) {
+        // Unused
     }
 
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/FileChooserField.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/FileChooserField.java
@@ -40,8 +40,8 @@ public class FileChooserField extends VisTable {
 
     private FileChooser.SelectionMode mode = FileChooser.SelectionMode.FILES;
     private FileSelected fileSelected;
-    private VisTextField textField;
-    private VisTextButton fcBtn;
+    private final VisTextField textField;
+    private final VisTextButton fcBtn;
 
     private String path;
     private FileHandle fileHandle;
@@ -107,6 +107,7 @@ public class FileChooserField extends VisTable {
                 super.clicked(event, x, y);
                 FileChooser fileChooser = UI.INSTANCE.getFileChooser();
                 fileChooser.setSelectionMode(mode);
+                fileChooser.setMultiSelectionEnabled(false);
                 fileChooser.setListener(new SingleFileChooserListener() {
                     @Override
                     protected void selected(FileHandle file) {


### PR DESCRIPTION
Adds the ability to drag and drop single + multiple textures into the import texture dialog. Also enables multi-selection for the image file chooser. 