### PR TITLE
Add frustum culling

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
@@ -29,14 +29,11 @@ import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
 import com.badlogic.gdx.graphics.glutils.FrameBuffer;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
-import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
 import com.mbrlabs.mundus.commons.assets.SkyboxAsset;
-import com.mbrlabs.mundus.commons.assets.TerrainAsset;
 import com.mbrlabs.mundus.commons.env.CameraSettings;
 import com.mbrlabs.mundus.commons.env.MundusEnvironment;
 import com.mbrlabs.mundus.commons.env.lights.DirectionalLight;
-import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
 import com.mbrlabs.mundus.commons.shaders.DepthShader;
 import com.mbrlabs.mundus.commons.shaders.ShadowMapShader;
@@ -61,11 +58,10 @@ public class Scene implements Disposable {
     private long id;
 
     public SceneGraph sceneGraph;
+    public SceneSettings settings;
     public MundusEnvironment environment;
     public Skybox skybox;
     public String skyboxAssetId;
-    public float waterHeight = 0f;
-    public WaterResolution waterResolution = WaterResolution.DEFAULT_WATER_RESOLUTION;
 
     public PerspectiveCamera cam;
     public ModelBatch batch;
@@ -82,10 +78,9 @@ public class Scene implements Disposable {
     protected Vector3 clippingPlaneReflection = new Vector3(0.0f, 1f, 0.0f);
     protected Vector3 clippingPlaneRefraction = new Vector3(0.0f, -1f, 0.0f);
 
-    private final float distortionEdgeCorrection = 1f;
-
     public Scene() {
         environment = new MundusEnvironment();
+        settings = new SceneSettings();
 
         cam = new PerspectiveCamera(CameraSettings.DEFAULT_FOV, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
         cam.position.set(0, 1, -3);
@@ -133,7 +128,7 @@ public class Scene implements Disposable {
 
     public void render(float delta) {
         if (fboWaterReflection == null) {
-            Vector2 res = waterResolution.getResolutionValues();
+            Vector2 res = settings.waterResolution.getResolutionValues();
             initFrameBuffers((int) res.x, (int) res.y);
         }
 
@@ -198,7 +193,7 @@ public class Scene implements Disposable {
 
     private void captureReflectionFBO(float delta) {
         // Calc vertical distance for camera for reflection FBO
-        float camReflectionDistance = 2 * (cam.position.y - waterHeight);
+        float camReflectionDistance = 2 * (cam.position.y - settings.waterHeight);
 
         // Save current cam positions
         Vector3 camPos = cam.position.cpy();
@@ -214,7 +209,7 @@ public class Scene implements Disposable {
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
         renderSkybox();
         batch.begin(cam);
-        sceneGraph.render(delta, clippingPlaneReflection, -waterHeight + distortionEdgeCorrection);
+        sceneGraph.render(delta, clippingPlaneReflection, -settings.waterHeight + settings.distortionEdgeCorrection);
         batch.end();
         fboWaterReflection.end();
 
@@ -229,7 +224,7 @@ public class Scene implements Disposable {
         fboDepthRefraction.begin();
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
         batch.begin(cam);
-        sceneGraph.renderDepth(delta, clippingPlaneRefraction, waterHeight + distortionEdgeCorrection, depthShader);
+        sceneGraph.renderDepth(delta, clippingPlaneRefraction, settings.waterHeight + settings.distortionEdgeCorrection, depthShader);
         batch.end();
         fboDepthRefraction.end();
     }
@@ -248,7 +243,7 @@ public class Scene implements Disposable {
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
         renderSkybox();
         batch.begin(cam);
-        sceneGraph.render(delta, clippingPlaneRefraction, waterHeight + distortionEdgeCorrection);
+        sceneGraph.render(delta, clippingPlaneRefraction, settings.waterHeight + settings.distortionEdgeCorrection);
         batch.end();
         fboWaterRefraction.end();
     }
@@ -296,8 +291,8 @@ public class Scene implements Disposable {
      * @param resolution the resolution to use
      */
     public void setWaterResolution(WaterResolution resolution) {
-        this.waterResolution = resolution;
-        Vector2 res = waterResolution.getResolutionValues();
+        settings.waterResolution = resolution;
+        Vector2 res = settings.waterResolution.getResolutionValues();
         initFrameBuffers((int) res.x, (int) res.y);
     }
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/SceneSettings.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/SceneSettings.java
@@ -1,0 +1,19 @@
+package com.mbrlabs.mundus.commons;
+
+import com.mbrlabs.mundus.commons.water.WaterResolution;
+
+/**
+ * Settings specific to a Scene.
+ * @author JamesTKhan
+ * @version July 23, 2022
+ */
+public class SceneSettings {
+
+    // Water
+    public float waterHeight = 0f;
+    public final float distortionEdgeCorrection = 1f;
+    public WaterResolution waterResolution = WaterResolution.DEFAULT_WATER_RESOLUTION;
+
+    // Performance
+    public boolean useFrustumCulling = true;
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/dto/SceneDTO.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/dto/SceneDTO.java
@@ -45,6 +45,7 @@ public class SceneDTO implements Json.Serializable {
     private float camFarPlane;
     private float camFieldOfView;
     private float waterHeight;
+    private boolean useFrustumCulling;
     private WaterResolution waterResolution;
 
     public SceneDTO() {
@@ -185,6 +186,14 @@ public class SceneDTO implements Json.Serializable {
 
     public float getWaterHeight() {
         return waterHeight;
+    }
+
+    public boolean isUseFrustumCulling() {
+        return useFrustumCulling;
+    }
+
+    public void setUseFrustumCulling(boolean useFrustumCulling) {
+        this.useFrustumCulling = useFrustumCulling;
     }
 
     public void setSkyboxAssetId(String skyboxAssetId) {

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
@@ -322,6 +322,18 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
     }
 
     @Override
+    public void scale(Vector3 v) {
+        super.scale(v);
+        scaleChanged = true;
+    }
+
+    @Override
+    public void scale(float x, float y, float z) {
+        super.scale(x,y,z);
+        scaleChanged = true;
+    }
+
+    @Override
     public Iterator<GameObject> iterator() {
         return new DepthFirstIterator(this);
     }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
@@ -37,6 +37,7 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
 
     public String name;
     public boolean active;
+    public boolean scaleChanged;
     private Array<String> tags;
     private Array<Component> components;
 
@@ -169,6 +170,9 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
                 }
             }
         }
+
+        // Reset after each update, after components have updated that might need to know about it
+        scaleChanged = false;
     }
 
     /**
@@ -308,6 +312,13 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
         if (component != null) {
             sceneGraph.scene.environment.remove(component.getLight());
         }
+    }
+
+    @Override
+    public void setLocalScale(float x, float y, float z) {
+        super.setLocalScale(x, y, z);
+        // We track when the scale has changed, for recalculating bounds for things like frustum culling
+        scaleChanged = true;
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.commons.scene3d.components;
+
+import com.badlogic.gdx.graphics.g3d.ModelInstance;
+import com.badlogic.gdx.math.Quaternion;
+import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.math.collision.BoundingBox;
+import com.mbrlabs.mundus.commons.scene3d.GameObject;
+
+import static com.mbrlabs.mundus.commons.utils.ModelUtils.isVisible;
+
+/**
+ * Components that can be Culled via Frustum Culling should extend
+ * this class and call setDimensions once they have access to a modelInstance as well as super
+ * for render() and update()
+ *
+ * The isCulled value will be set accordingly and components can check if is isCulled == true
+ * before rendering.
+ *
+ * @author JamesTKhan
+ * @version July 18, 2022
+ */
+public abstract class CullableComponent extends AbstractComponent {
+    private final static BoundingBox tmpBounds = new BoundingBox();
+    private final static Quaternion quaternion = new Quaternion();
+    private final static Vector3 tmpScale = new Vector3();
+
+    public final Vector3 center = new Vector3();
+    public final Vector3 dimensions = new Vector3();
+    public float radius;
+
+    // Is it offscreen?
+    protected boolean isCulled = false;
+    private ModelInstance modelInstance = null;
+
+    public CullableComponent(GameObject go) {
+        super(go);
+    }
+
+    @Override
+    public void render(float delta) {
+        if (modelInstance == null) return;
+        gameObject.getLocalRotation(quaternion);
+
+        if (quaternion.isIdentity()) {
+            // If it's not rotated, we use boundsInFrustum which seems to kick in quicker on terrains and water
+            // since it's not taking all possible rotations of the object into account
+            isCulled = !isVisible(gameObject.sceneGraph.scene.cam, modelInstance, center, dimensions);
+        } else {
+            isCulled = !isVisible(gameObject.sceneGraph.scene.cam, modelInstance, center, radius);
+        }
+
+    }
+
+    @Override
+    public void update(float delta) {
+        if (gameObject.scaleChanged) {
+            setDimensions(modelInstance);
+        }
+    }
+
+    protected void setDimensions(ModelInstance modelInstance) {
+        this.modelInstance = modelInstance;
+        modelInstance.calculateBoundingBox(tmpBounds);
+        tmpBounds.getCenter(center);
+        tmpBounds.getDimensions(dimensions);
+        dimensions.scl(gameObject.getLocalScale(tmpScale));
+        radius = dimensions.len() / 2f;
+    }
+
+    public boolean isCulled() {
+        return isCulled;
+    }
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
@@ -34,7 +34,7 @@ import java.util.Objects;
  * @author Marcus Brummer
  * @version 17-01-2016
  */
-public class ModelComponent extends AbstractComponent implements AssetUsage, ClippableComponent {
+public class ModelComponent extends CullableComponent implements AssetUsage, ClippableComponent {
 
     protected ModelAsset modelAsset;
     protected ModelInstance modelInstance;
@@ -75,6 +75,8 @@ public class ModelComponent extends AbstractComponent implements AssetUsage, Cli
             }
         }
         applyMaterials();
+
+        setDimensions(modelInstance);
     }
 
     public ObjectMap<String, MaterialAsset> getMaterials() {
@@ -100,6 +102,9 @@ public class ModelComponent extends AbstractComponent implements AssetUsage, Cli
 
     @Override
     public void render(float delta) {
+        super.render(delta);
+        if (isCulled) return;
+
         modelInstance.transform.set(gameObject.getTransform());
         if (shader != null) {
             gameObject.sceneGraph.scene.batch.render(modelInstance, gameObject.sceneGraph.scene.environment, shader);
@@ -110,6 +115,8 @@ public class ModelComponent extends AbstractComponent implements AssetUsage, Cli
 
     @Override
     public void renderDepth(float delta, Vector3 clippingPlane, float clipHeight, Shader shader) {
+        if (isCulled) return;
+
         if (shader instanceof ClippableShader) {
             ((ClippableShader) shader).setClippingPlane(clippingPlane);
             ((ClippableShader) shader).setClippingHeight(clipHeight);
@@ -130,11 +137,6 @@ public class ModelComponent extends AbstractComponent implements AssetUsage, Cli
         }
 
         render(delta);
-    }
-
-    @Override
-    public void update(float delta) {
-
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/TerrainComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/TerrainComponent.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * @author Marcus Brummer
  * @version 18-01-2016
  */
-public class TerrainComponent extends AbstractComponent implements AssetUsage, ClippableComponent {
+public class TerrainComponent extends CullableComponent implements AssetUsage, ClippableComponent {
 
     private static final String TAG = TerrainComponent.class.getSimpleName();
 
@@ -49,6 +49,7 @@ public class TerrainComponent extends AbstractComponent implements AssetUsage, C
 
     public void setTerrain(TerrainAsset terrain) {
         this.terrain = terrain;
+        setDimensions(terrain.getTerrain().modelInstance);
     }
 
     public TerrainAsset getTerrain() {
@@ -65,6 +66,8 @@ public class TerrainComponent extends AbstractComponent implements AssetUsage, C
 
     @Override
     public void render(float delta) {
+        super.render(delta);
+        if (isCulled) return;
         gameObject.sceneGraph.scene.batch.render(terrain.getTerrain(), gameObject.sceneGraph.scene.environment, shader);
     }
 
@@ -79,17 +82,14 @@ public class TerrainComponent extends AbstractComponent implements AssetUsage, C
 
     @Override
     public void renderDepth(float delta, Vector3 clippingPlane, float clipHeight, Shader shader) {
+        if (isCulled) return;
+
         if (shader instanceof ClippableShader) {
             ((ClippableShader) shader).setClippingPlane(clippingPlane);
             ((ClippableShader) shader).setClippingHeight(clipHeight);
         }
 
         gameObject.sceneGraph.scene.batch.render(terrain.getTerrain(), gameObject.sceneGraph.scene.environment, shader);
-    }
-
-    @Override
-    public void update(float delta) {
-
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/WaterComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/WaterComponent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2022. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mbrlabs.mundus.commons.scene3d.components;
 
 import com.badlogic.gdx.Gdx;
@@ -7,7 +23,7 @@ import com.mbrlabs.mundus.commons.assets.WaterAsset;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.water.WaterFloatAttribute;
 
-public class WaterComponent extends AbstractComponent implements AssetUsage {
+public class WaterComponent extends CullableComponent implements AssetUsage {
 
     protected WaterAsset waterAsset;
     protected Shader shader;
@@ -26,6 +42,7 @@ public class WaterComponent extends AbstractComponent implements AssetUsage {
 
     public void setWaterAsset(WaterAsset waterAsset) {
         this.waterAsset = waterAsset;
+        setDimensions(waterAsset.water.modelInstance);
     }
 
     public Shader getShader() {
@@ -43,6 +60,8 @@ public class WaterComponent extends AbstractComponent implements AssetUsage {
 
     @Override
     public void render(float delta) {
+        super.render(delta);
+        if (isCulled) return;
         gameObject.sceneGraph.scene.batch.render(waterAsset.water, gameObject.sceneGraph.scene.environment, shader);
     }
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/utils/ModelUtils.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/utils/ModelUtils.java
@@ -1,8 +1,26 @@
+/*
+ * Copyright (c) 2022. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mbrlabs.mundus.commons.utils;
 
+import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.graphics.g3d.Renderable;
+import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Pool;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
@@ -16,6 +34,7 @@ import com.mbrlabs.mundus.commons.scene3d.components.ModelComponent;
 public class ModelUtils {
     private static final Array<Renderable> renderables = new Array<>();
     private static final Pool<Renderable> pool = new RenderablePool();
+    private final static Vector3 tmpVec0 = new Vector3();
 
     private ModelUtils() {}
 
@@ -59,5 +78,23 @@ public class ModelUtils {
         for (GameObject go : rootGameObject.getChildren()) {
             applyGameObjectMaterials(go);
         }
+    }
+
+    /**
+     * Checks if visible to camera using sphereInFrustum and radius
+     */
+    public static boolean isVisible(final Camera cam, final ModelInstance modelInstance, Vector3 center, float radius) {
+        modelInstance.transform.getTranslation(tmpVec0);
+        tmpVec0.add(center);
+        return cam.frustum.sphereInFrustum(tmpVec0, radius);
+    }
+
+    /**
+     * Checks if visible to camera using boundsInFrustum and dimensions
+     */
+    public static boolean isVisible(final Camera cam, final ModelInstance modelInstance, Vector3 center, Vector3 dimensions) {
+        modelInstance.transform.getTranslation(tmpVec0);
+        tmpVec0.add(center);
+        return cam.frustum.boundsInFrustum(tmpVec0, dimensions);
     }
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
@@ -166,7 +166,7 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
     override fun onFullScreenEvent(event: FullScreenEvent) {
         if (event.isFullScreen) return
         // looks redundant but the purpose is to reset the FBO's to clear a render glitch on full screen exit
-        projectManager.current().currScene.setWaterResolution(projectManager.current().currScene.waterResolution)
+        projectManager.current().currScene.setWaterResolution(projectManager.current().currScene.settings.waterResolution)
     }
 
     private fun createDefaultProject(): ProjectContext? {

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/converter/SceneConverter.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/converter/SceneConverter.java
@@ -63,8 +63,10 @@ public class SceneConverter {
         dto.setDirectionalLight(DirectionalLightConverter.convert(scene, directionalLight.lights.first()));
 
         // Water
-        dto.setWaterResolution(scene.waterResolution);
-        dto.setWaterHeight(scene.waterHeight);
+        dto.setWaterResolution(scene.settings.waterResolution);
+        dto.setWaterHeight(scene.settings.waterHeight);
+
+        dto.setUseFrustumCulling(scene.settings.useFrustumCulling);
 
         // camera
         dto.setCamPosX(scene.cam.position.x);
@@ -105,11 +107,12 @@ public class SceneConverter {
         }
 
         // Water stuff
-        scene.waterResolution = dto.getWaterResolution();
-        if (scene.waterResolution == null)
-            scene.waterResolution = WaterResolution.DEFAULT_WATER_RESOLUTION;
+        scene.settings.waterResolution = dto.getWaterResolution();
+        if (scene.settings.waterResolution == null)
+            scene.settings.waterResolution = WaterResolution.DEFAULT_WATER_RESOLUTION;
 
-        scene.waterHeight = dto.getWaterHeight();
+        scene.settings.waterHeight = dto.getWaterHeight();
+        scene.settings.useFrustumCulling = dto.isUseFrustumCulling();
 
         // scene graph
         scene.sceneGraph = new SceneGraph(scene);

--- a/editor/src/main/com/mbrlabs/mundus/editor/tools/TranslateTool.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/tools/TranslateTool.java
@@ -68,6 +68,7 @@ public class TranslateTool extends TransformTool {
     private boolean globalSpace = true;
 
     private final Vector3 temp0 = new Vector3();
+    private final Vector3 temp1 = new Vector3();
 
     private TranslateCommand command;
 
@@ -193,7 +194,7 @@ public class TranslateTool extends TransformTool {
 
             // If a water component height is changed, global water height needs to update
             if (go.findComponentByType(Component.Type.WATER) != null)
-                getProjectManager().current().currScene.waterHeight = go.getPosition(new Vector3()).y;
+                getProjectManager().current().currScene.settings.waterHeight = go.getPosition(temp1).y;
 
             if (modified) {
                 gameObjectModifiedEvent.setGameObject(getProjectManager().current().currScene.currentSelection);

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/PerformanceSettingsTable.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/PerformanceSettingsTable.kt
@@ -1,0 +1,69 @@
+package com.mbrlabs.mundus.editor.ui.modules.dialogs.settings
+
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
+import com.kotcrab.vis.ui.widget.VisCheckBox
+import com.kotcrab.vis.ui.widget.VisLabel
+import com.kotcrab.vis.ui.widget.VisTable
+import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.core.project.ProjectManager
+import com.mbrlabs.mundus.editor.core.scene.SceneManager
+import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
+import com.mbrlabs.mundus.editor.events.SceneChangedEvent
+import com.mbrlabs.mundus.editor.ui.UI
+import com.mbrlabs.mundus.editor.ui.widgets.ToolTipLabel
+
+/**
+ * @author JamesTKhan
+ * @version July 23, 2022
+ */
+class PerformanceSettingsTable : BaseSettingsTable(), ProjectChangedEvent.ProjectChangedListener, SceneChangedEvent.SceneChangedListener {
+
+    private val projectManager: ProjectManager = Mundus.inject()
+
+    private val frustumCullingChkBox = VisCheckBox(null)
+
+    init {
+        Mundus.registerEventListener(this)
+        top().left()
+        defaults().left().pad(4f)
+
+        add(VisLabel("Camera Settings")).row()
+        addSeparator().padBottom(10f).row()
+
+        val settingsTable = VisTable()
+        settingsTable.defaults().left().pad(4f)
+        val frustumLabel = ToolTipLabel("Perform Frustum Culling (Per Scene)", "Frustum Culling increase performance by not rendering offscreen " +
+            "objects.\nThis is done by calculating the bounds of GameObjects models and checking for intersections on the camera frustum.\n" +
+                "If objects are being culled while still on screen make sure all transforms are applied to your model in your modeling application.\n" +
+                "\nNote: If you are using shadows, then the shadow frustum is also used to test for visibility to allow for shadows to appear from offscreen objects.\n" +
+            "This means that objects directly behind the player may not be culled until also out of the shadow frustum.")
+
+        settingsTable.add(frustumLabel)
+        settingsTable.add(frustumCullingChkBox).row()
+        add(settingsTable)
+
+        frustumCullingChkBox.addListener(object : ChangeListener() {
+            override fun changed(event: ChangeEvent, actor: Actor) {
+                projectManager.current().currScene.settings.useFrustumCulling = frustumCullingChkBox.isChecked
+            }
+        })
+    }
+
+    private fun updateValues() {
+        frustumCullingChkBox.isChecked = projectManager.current().currScene.settings.useFrustumCulling
+    }
+
+    override fun onSave() {
+        SceneManager.saveScene(projectManager.current(), projectManager.current().currScene)
+        UI.toaster.success("Settings saved")
+    }
+
+    override fun onProjectChanged(event: ProjectChangedEvent) {
+        updateValues()
+    }
+
+    override fun onSceneChanged(event: SceneChangedEvent) {
+        updateValues()
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/PerformanceSettingsTable.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/PerformanceSettingsTable.kt
@@ -28,7 +28,7 @@ class PerformanceSettingsTable : BaseSettingsTable(), ProjectChangedEvent.Projec
         top().left()
         defaults().left().pad(4f)
 
-        add(VisLabel("Camera Settings")).row()
+        add(VisLabel("Performance Settings")).row()
         addSeparator().padBottom(10f).row()
 
         val settingsTable = VisTable()

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/SettingsDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/SettingsDialog.kt
@@ -45,6 +45,7 @@ class SettingsDialog : BaseDialog("Settings") {
     private val exportSettings = ExportSettingsTable()
     private val appearenceSettings = AppearanceSettingsTable()
     private val cameraSettings = CameraSettingsTable()
+    private val performanceSettings = PerformanceSettingsTable()
 
     init {
         val root = VisTable()
@@ -73,6 +74,10 @@ class SettingsDialog : BaseDialog("Settings") {
         val cameraNode = SettingsNode(VisLabel("Camera"))
         cameraNode.value = cameraSettings
         settingsTree.add(cameraNode)
+
+        val perfNode = SettingsNode(VisLabel("Performance"))
+        perfNode.value = performanceSettings
+        settingsTree.add(perfNode)
 
         // listener
         settingsTree.addListener(object : ClickListener() {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/TransformWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/TransformWidget.kt
@@ -112,7 +112,7 @@ class TransformWidget : BaseInspectorWidget("Transformation") {
 
                 // If a water component height is changed, global water height needs to update
                 if (go.findComponentByType(Component.Type.WATER) != null)
-                    projectManager.current().currScene.waterHeight = go.getPosition(Vector3()).y
+                    projectManager.current().currScene.settings.waterHeight = go.getPosition(Vector3()).y
             }
         })
         posZ.addListener(object : ChangeListener() {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/WaterWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/WaterWidget.kt
@@ -157,7 +157,7 @@ class WaterWidget(val waterComponent: WaterComponent) : VisTable() {
                 waterComponent.waterAsset.water.setFloatAttribute(WaterFloatAttribute.FoamEdgeDistance, Water.DEFAULT_FOAM_EDGE_DISTANCE)
                 waterComponent.waterAsset.water.setFloatAttribute(WaterFloatAttribute.FoamEdgeBias, Water.DEFAULT_FOAM_EDGE_BIAS)
                 waterComponent.waterAsset.water.setFloatAttribute(WaterFloatAttribute.FoamFallOffDistance, Water.DEFAULT_FOAM_FALL_OFF_DISTANCE)
-                projectManager.current().currScene.waterResolution = WaterResolution.DEFAULT_WATER_RESOLUTION
+                projectManager.current().currScene.settings.waterResolution = WaterResolution.DEFAULT_WATER_RESOLUTION
                 projectManager.current().assetManager.addModifiedAsset(waterComponent.waterAsset)
 
                 setFieldsToCurrentValues()
@@ -195,7 +195,7 @@ class WaterWidget(val waterComponent: WaterComponent) : VisTable() {
         foamScrollSpeedFactor.text = waterComponent.waterAsset.water.getFloatAttribute(WaterFloatAttribute.FoamScrollSpeed).toString()
         foamFallOffDistance.text = waterComponent.waterAsset.water.getFloatAttribute(WaterFloatAttribute.FoamFallOffDistance).toString()
         foamEdgeDistance.text = waterComponent.waterAsset.water.getFloatAttribute(WaterFloatAttribute.FoamEdgeDistance).toString()
-        selectBox.selected = projectManager.current().currScene.waterResolution.value
+        selectBox.selected = projectManager.current().currScene.settings.waterResolution.value
     }
 
     private fun getSectionTable(): VisTable {

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/SceneConverter.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/SceneConverter.java
@@ -62,11 +62,12 @@ public class SceneConverter {
         }
 
         // Water stuff
-        scene.waterResolution = dto.getWaterResolution();
-        if (scene.waterResolution == null)
-            scene.waterResolution = WaterResolution.DEFAULT_WATER_RESOLUTION;
+        scene.settings.waterResolution = dto.getWaterResolution();
+        if (scene.settings.waterResolution == null)
+            scene.settings.waterResolution = WaterResolution.DEFAULT_WATER_RESOLUTION;
 
-        scene.waterHeight = dto.getWaterHeight();
+        scene.settings.waterHeight = dto.getWaterHeight();
+        scene.settings.useFrustumCulling = dto.isUseFrustumCulling();
 
         // scene graph
         scene.sceneGraph = new SceneGraph(scene);


### PR DESCRIPTION
Adds frustum culling for Models, Terrains, and Water to help with performance. If shadows are enabled, the shadow map camera frustum is also factored in for culling. Also adds a SceneSettings object and water settings were moved into that object. Also adds a performance settings area for frustum culling toggling per scene.

Observe profiler stats with objects in view:
![image](https://user-images.githubusercontent.com/28971753/179668936-f8749462-b208-49cb-a2d3-220b1b6f1e1b.png)

Turning the camera away and observe profiler stats with frustum culling enabled
![image](https://user-images.githubusercontent.com/28971753/179669108-5e92c0ba-67f6-4222-8dd7-f58f8de6460d.png)


![image](https://user-images.githubusercontent.com/28971753/180626772-2d9e7193-4419-4530-aad9-ea1d576a373e.png)

