### PR TITLE
Track last open directory for FileChooser per project

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -7,10 +7,18 @@
 - Added new Add Component Dialog which only supports Light Components for now.
 - Added new Gizmo feature for displaying decal Icons over objects like Light sources.
 - Added normal mapping for terrains and models
+- Added Frustum Culling which can be toggled in Window -> Settings -> Performance
+- Added multi-texture importing with drag and drop
 - Added new profiling bar with GL profiler statistics
 - Added experimental basic directional light shadows
+- Added tracking per project for Last Open Directory on File Choosers
+- Added terrain smoothing brush
+- Added configurable camera settings Window -> Settings -> Camera
 - Update water shader to fade out water foam over distance, to minimize ugly 1 pixel white lines from a distance.
 - Fix broken checkbox to set game objects to active or inactive
+- Fix File Choosers stored favorites under the wrong key name
+- Fix bug with not being able to paint on terrains != 0 height.
+- Fix toast messages not displaying
 
 [0.3.1] ~ 07/06/2022
 - Added functionality to the editor to generate the assets.txt file, PR #45

--- a/editor/src/main/com/mbrlabs/mundus/editor/Mundus.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Mundus.kt
@@ -25,8 +25,9 @@ import com.badlogic.gdx.graphics.glutils.ShapeRenderer
 import com.badlogic.gdx.scenes.scene2d.ui.Skin
 import com.badlogic.gdx.utils.Json
 import com.kotcrab.vis.ui.VisUI
+import com.kotcrab.vis.ui.widget.file.FileChooser
 import com.mbrlabs.mundus.commons.assets.meta.MetaLoader
-import com.mbrlabs.mundus.editor.preferences.GlobalPreferencesManager
+import com.mbrlabs.mundus.editor.preferences.MundusPreferencesManager
 import com.mbrlabs.mundus.editor.assets.MetaSaver
 import com.mbrlabs.mundus.editor.assets.ModelImporter
 import com.mbrlabs.mundus.editor.core.kryo.KryoManager
@@ -80,10 +81,12 @@ object Mundus {
     private val goPicker: GameObjectPicker
     private val handlePicker: ToolHandlePicker
     private val json: Json
-    private val globalPrefManager: GlobalPreferencesManager
+    private val globalPrefManager: MundusPreferencesManager
     private val glProfiler: MundusGLProfiler
 
     init {
+        FileChooser.setDefaultPrefsName("mundus.editor.filechooser")
+
         // create home dir
         val homeDir = File(Registry.HOME_DIR)
         if (!homeDir.exists()) {
@@ -112,7 +115,7 @@ object Mundus {
         gizmoManager = GizmoManager()
         shortcutController = ShortcutController(registry, projectManager, commandHistory, toolManager)
         json = Json()
-        globalPrefManager = GlobalPreferencesManager()
+        globalPrefManager = MundusPreferencesManager("global")
         glProfiler = MundusGLProfiler(Gdx.graphics)
 
         // add to DI container

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectContext.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectContext.java
@@ -18,9 +18,12 @@ package com.mbrlabs.mundus.editor.core.project;
 
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
+import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.mbrlabs.mundus.editor.assets.EditorAssetManager;
 import com.mbrlabs.mundus.editor.core.EditorScene;
+import com.mbrlabs.mundus.editor.preferences.MundusPreferencesManager;
 import com.mbrlabs.mundus.editor.utils.Log;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * A project context represents an loaded and opened project.
@@ -43,6 +46,7 @@ public class ProjectContext implements Disposable {
     public EditorScene currScene;
 
     public EditorAssetManager assetManager;
+    public MundusPreferencesManager projectPref;
 
     private int idProvider;
 
@@ -73,4 +77,14 @@ public class ProjectContext implements Disposable {
         }
     }
 
+    /**
+     * Initializes this projects Preferences manager
+     * The project name must be set before calling this method.
+     */
+    public void initPreferences() {
+        if (StringUtils.isEmpty(name)) {
+            throw new GdxRuntimeException("Cannot initialize preferences if project name is null or blank.");
+        }
+        projectPref = new MundusPreferencesManager(name);
+    }
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -368,6 +368,7 @@ public class ProjectManager implements Disposable {
         }
 
         currentProject = context;
+        currentProject.initPreferences();
         // currentProject.copyFrom(context);
         registry.setLastProject(new ProjectRef());
         registry.getLastOpenedProject().setName(context.name);

--- a/editor/src/main/com/mbrlabs/mundus/editor/preferences/MundusPreferencesManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/preferences/MundusPreferencesManager.kt
@@ -4,19 +4,27 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.Preferences
 
 /**
- * Manages global preferences for Mundus regardless of current project
+ * Manages preferences using the given key value
  *
  * @author JamesTKhan
  * @version July 14, 2022
  */
-class GlobalPreferencesManager : PreferencesManager {
+class MundusPreferencesManager(preferencesKey: String) : PreferencesManager {
     companion object {
-        private val TAG = GlobalPreferencesManager::class.java.simpleName
+        private val TAG = MundusPreferencesManager::class.java.simpleName
 
-        var MUNDUS_VERSION = "version"
+        // Keys for global prefs
+        var GLOB_MUNDUS_VERSION = "version"
+
+        // Keys for project specific prefs
+        var PROJ_LAST_DIR = "lastDirectoryOpened"
     }
 
-    private var globalPrefs: Preferences = Gdx.app.getPreferences("mundus.global")
+    private var preferences: Preferences
+
+    init {
+        preferences = Gdx.app.getPreferences("mundus.$preferencesKey")
+    }
 
     /**
      * Set a value in preferences
@@ -24,82 +32,82 @@ class GlobalPreferencesManager : PreferencesManager {
      */
     override fun set(key: String, value: Any) {
         when(value) {
-            is Boolean -> globalPrefs.putBoolean(key, value)
-            is String -> globalPrefs.putString(key, value)
-            is Int -> globalPrefs.putInteger(key, value)
-            is Long -> globalPrefs.putLong(key, value)
-            is Float -> globalPrefs.putFloat(key, value)
+            is Boolean -> preferences.putBoolean(key, value)
+            is String -> preferences.putString(key, value)
+            is Int -> preferences.putInteger(key, value)
+            is Long -> preferences.putLong(key, value)
+            is Float -> preferences.putFloat(key, value)
             else -> {
                 Gdx.app.error(TAG, "Invalid object type given for preferences.")
                 return
             }
         }
 
-        globalPrefs.flush()
+        preferences.flush()
     }
 
     fun set(value: MutableMap<String, *>) {
-        globalPrefs.put(value)
+        preferences.put(value)
     }
 
     override fun get(key: String, type: Class<*>): Any? {
         if (type == Boolean::class.java) {
-            return globalPrefs.getBoolean(key, false)
+            return preferences.getBoolean(key, false)
         }
         return null
     }
 
     override fun getBoolean(key: String): Boolean {
-        return globalPrefs.getBoolean(key)
+        return preferences.getBoolean(key)
     }
 
     override fun getBoolean(key: String, defValue: Boolean): Boolean {
-        return globalPrefs.getBoolean(key, defValue)
+        return preferences.getBoolean(key, defValue)
     }
 
     override fun getInteger(key: String): Int {
-        return globalPrefs.getInteger(key)
+        return preferences.getInteger(key)
     }
 
     override fun getInteger(key: String, defValue: Int): Int {
-        return globalPrefs.getInteger(key, defValue)
+        return preferences.getInteger(key, defValue)
     }
 
     override fun getLong(key: String): Long {
-        return globalPrefs.getLong(key)
+        return preferences.getLong(key)
     }
 
     override fun getLong(key: String, defValue: Long): Long {
-        return globalPrefs.getLong(key, defValue)
+        return preferences.getLong(key, defValue)
     }
 
     override fun getFloat(key: String): Float {
-        return globalPrefs.getFloat(key)
+        return preferences.getFloat(key)
     }
 
     override fun getFloat(key: String, defValue: Float): Float {
-        return globalPrefs.getFloat(key, defValue)
+        return preferences.getFloat(key, defValue)
     }
 
     override fun getString(key: String): String {
-        return globalPrefs.getString(key)
+        return preferences.getString(key)
     }
 
     override fun getString(key: String?, defValue: String?): String {
-        globalPrefs.get()
-        return globalPrefs.getString(key, defValue)
+        preferences.get()
+        return preferences.getString(key, defValue)
     }
 
     override fun contains(key: String): Boolean {
-        return globalPrefs.contains(key)
+        return preferences.contains(key)
     }
 
     override fun remove(key: String) {
-        globalPrefs.remove(key)
+        preferences.remove(key)
     }
 
     override fun clear() {
-        globalPrefs.clear()
+        preferences.clear()
     }
 
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/UI.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/UI.kt
@@ -27,7 +27,7 @@ import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.Mundus.postEvent
 import com.mbrlabs.mundus.editor.VERSION
 import com.mbrlabs.mundus.editor.events.FullScreenEvent
-import com.mbrlabs.mundus.editor.preferences.GlobalPreferencesManager
+import com.mbrlabs.mundus.editor.preferences.MundusPreferencesManager
 import com.mbrlabs.mundus.editor.ui.modules.MundusToolbar
 import com.mbrlabs.mundus.editor.ui.modules.Outline
 import com.mbrlabs.mundus.editor.ui.modules.StatusBar
@@ -51,6 +51,7 @@ import com.mbrlabs.mundus.editor.ui.modules.inspector.Inspector
 import com.mbrlabs.mundus.editor.ui.modules.menu.MundusMenuBar
 import com.mbrlabs.mundus.editor.ui.widgets.MundusMultiSplitPane
 import com.mbrlabs.mundus.editor.ui.widgets.MundusSplitPane
+import com.mbrlabs.mundus.editor.ui.widgets.PersistingFileChooser
 import com.mbrlabs.mundus.editor.ui.widgets.RenderWidget
 import com.mbrlabs.mundus.editor.utils.Toaster
 
@@ -70,7 +71,7 @@ object UI : Stage(ScreenViewport()) {
 
     // reusable ui elements
     val toaster: Toaster = Toaster(this)
-    val fileChooser: FileChooser = FileChooser(FileChooser.Mode.OPEN)
+    val fileChooser: FileChooser = PersistingFileChooser(FileChooser.Mode.OPEN)
     val assetSelectionDialog: AssetPickerDialog = AssetPickerDialog()
 
     // base elements
@@ -104,10 +105,9 @@ object UI : Stage(ScreenViewport()) {
     // styles
     val greenSeperatorStyle: Separator.SeparatorStyle
 
-    private var globalPrefManager: GlobalPreferencesManager
+    private var globalPrefManager: MundusPreferencesManager
 
     init {
-        FileChooser.setDefaultPrefsName("com.mbrlabs.mundus.editor")
         greenSeperatorStyle = Separator.SeparatorStyle(VisUI.getSkin().getDrawable("mundus-separator-green"), 1)
 
         globalPrefManager = Mundus.inject()
@@ -195,10 +195,10 @@ object UI : Stage(ScreenViewport()) {
      * Conditionally displays the versioning dialog based on stored preferences
      */
     fun processVersionDialog() {
-        val previousVersion = globalPrefManager.getString(GlobalPreferencesManager.MUNDUS_VERSION, "null")
+        val previousVersion = globalPrefManager.getString(MundusPreferencesManager.GLOB_MUNDUS_VERSION, "null")
         if (previousVersion != VERSION) {
             // If version changed, display dialog
-            globalPrefManager.set(GlobalPreferencesManager.MUNDUS_VERSION, VERSION)
+            globalPrefManager.set(MundusPreferencesManager.GLOB_MUNDUS_VERSION, VERSION)
             showDialog(versionDialog)
         }
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/PersistingFileChooser.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/PersistingFileChooser.kt
@@ -1,0 +1,43 @@
+package com.mbrlabs.mundus.editor.ui.widgets
+
+import com.kotcrab.vis.ui.widget.file.FileChooser
+import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.core.project.ProjectManager
+import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
+import com.mbrlabs.mundus.editor.preferences.MundusPreferencesManager
+
+/**
+ * Extends FileChooser to add behavior that sets the current chooser directory to the
+ * current projects last opened directory on project change
+ *
+ * @author JamesTKhan
+ * @version July 19, 2022
+ */
+class PersistingFileChooser(mode: Mode) : FileChooser(mode), ProjectChangedEvent.ProjectChangedListener {
+
+    private var projectManager: ProjectManager = Mundus.inject()
+
+    init {
+        Mundus.registerEventListener(this)
+    }
+
+    /**
+     * Load the last opened directory for this project, and set that as the current directory for filechooser
+     */
+    private fun setLastOpenedDirectory() {
+        if (projectManager.current().projectPref.contains(MundusPreferencesManager.PROJ_LAST_DIR)) {
+            val path = projectManager.current().projectPref.getString(MundusPreferencesManager.PROJ_LAST_DIR)
+            setDirectory(path)
+        }
+    }
+
+    override fun fadeOut() {
+        super.fadeOut()
+        // On fade out of the chooser, store the last opened directory
+        projectManager.current().projectPref.set(MundusPreferencesManager.PROJ_LAST_DIR, currentDirectory.pathWithoutExtension())
+    }
+
+    override fun onProjectChanged(event: ProjectChangedEvent) {
+        setLastOpenedDirectory()
+    }
+}


### PR DESCRIPTION
Extends FileChooser and makes Preferences manager a bit more reusable. Now there is a global preferences and a project preferences file. Project preferences file will now store last opened directory from a file chooser. On project loading that directory is read from preferences and applied. Projects preferences manager lives within project context

FileChooser.setDefaultPrefsName was also moved as it was not being called before file chooser initialization and thus the preferences key was not being used. 