### PR TITLE
Fix scaled UV on import, add widgets

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/MaterialAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/MaterialAsset.java
@@ -18,6 +18,7 @@ package com.mbrlabs.mundus.commons.assets;
 
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g3d.Material;
 import com.badlogic.gdx.graphics.g3d.attributes.BlendingAttribute;
 import com.badlogic.gdx.graphics.g3d.attributes.IntAttribute;
@@ -76,6 +77,12 @@ public class MaterialAsset extends Asset {
     private TextureAsset metallicRoughnessTexture;
     private TextureAsset occlusionTexture;
 
+    public TexCoordInfo diffuseTexCoord = new TexCoordInfo("diffuse");
+    public TexCoordInfo normalTexCoord = new TexCoordInfo("map");
+    public TexCoordInfo emissiveTexCoord = new TexCoordInfo("emissive");
+    public TexCoordInfo metallicRoughnessTexCoord = new TexCoordInfo("metallicRoughTexture");
+    public TexCoordInfo occlusionTexCoord = new TexCoordInfo("occlusionTexture");
+
     private float roughness = 1f;
     private float metallic = 0f;
     private float opacity = 1f;
@@ -124,6 +131,13 @@ public class MaterialAsset extends Asset {
                 if (value != null) {
                     cullFace = Integer.parseInt(value);
                 }
+
+                populateTexCoordInfo(diffuseTexCoord);
+                populateTexCoordInfo(normalTexCoord);
+                populateTexCoordInfo(emissiveTexCoord);
+                populateTexCoordInfo(metallicRoughnessTexCoord);
+                populateTexCoordInfo(occlusionTexCoord);
+
             } catch (NumberFormatException nfe) {
                 nfe.printStackTrace();
             }
@@ -151,6 +165,33 @@ public class MaterialAsset extends Asset {
         }
     }
 
+    private void populateTexCoordInfo(TexCoordInfo texCoordInfo) {
+        String value = MAP.get(texCoordInfo.PROP_UV, null);
+        if (value != null) {
+            texCoordInfo.uvIndex = Integer.parseInt(value);
+        }
+        value = MAP.get(texCoordInfo.PROP_OFFSET_U, null);
+        if (value != null) {
+            texCoordInfo.offsetU = Float.parseFloat(value);
+        }
+        value = MAP.get(texCoordInfo.PROP_OFFSET_V, null);
+        if (value != null) {
+            texCoordInfo.offsetV = Float.parseFloat(value);
+        }
+        value = MAP.get(texCoordInfo.PROP_SCALE_U, null);
+        if (value != null) {
+            texCoordInfo.scaleU = Float.parseFloat(value);
+        }
+        value = MAP.get(texCoordInfo.PROP_SCALE_V, null);
+        if (value != null) {
+            texCoordInfo.scaleV = Float.parseFloat(value);
+        }
+        value = MAP.get(texCoordInfo.PROP_ROTATION_UV, null);
+        if (value != null) {
+            texCoordInfo.rotationUV = Float.parseFloat(value);
+        }
+    }
+
     /**
      * Applies this material asset to the libGDX material.
      *
@@ -165,27 +206,27 @@ public class MaterialAsset extends Asset {
             material.set(PBRColorAttribute.createEmissive(emissiveColor));
         }
         if (diffuseTexture != null) {
-            material.set(new PBRTextureAttribute(PBRTextureAttribute.BaseColorTexture, diffuseTexture.getTexture()));
+            material.set(getTextureAttribute(PBRTextureAttribute.BaseColorTexture, diffuseTexture.getTexture(), diffuseTexCoord));
         } else {
-            material.remove(PBRTextureAttribute.Diffuse);
+            material.remove(PBRTextureAttribute.BaseColorTexture);
         }
         if (normalMap != null) {
-            material.set(new PBRTextureAttribute(PBRTextureAttribute.NormalTexture, normalMap.getTexture()));
+            material.set(getTextureAttribute(PBRTextureAttribute.NormalTexture, normalMap.getTexture(), normalTexCoord));
         } else {
             material.remove(PBRTextureAttribute.NormalTexture);
         }
         if (emissiveTexture != null) {
-            material.set(new PBRTextureAttribute(PBRTextureAttribute.EmissiveTexture, emissiveTexture.getTexture()));
+            material.set(getTextureAttribute(PBRTextureAttribute.EmissiveTexture, emissiveTexture.getTexture(), emissiveTexCoord));
         } else {
             material.remove(PBRTextureAttribute.EmissiveTexture);
         }
         if (metallicRoughnessTexture != null) {
-            material.set(new PBRTextureAttribute(PBRTextureAttribute.MetallicRoughnessTexture, metallicRoughnessTexture.getTexture()));
+            material.set(getTextureAttribute(PBRTextureAttribute.MetallicRoughnessTexture, metallicRoughnessTexture.getTexture(), metallicRoughnessTexCoord));
         } else {
             material.remove(PBRTextureAttribute.MetallicRoughnessTexture);
         }
         if (occlusionTexture != null) {
-            material.set(new PBRTextureAttribute(PBRTextureAttribute.OcclusionTexture, occlusionTexture.getTexture()));
+            material.set(getTextureAttribute(PBRTextureAttribute.OcclusionTexture, occlusionTexture.getTexture(), occlusionTexCoord));
         } else {
             material.remove(PBRTextureAttribute.OcclusionTexture);
         }
@@ -221,6 +262,21 @@ public class MaterialAsset extends Asset {
         }
 
         return material;
+    }
+
+    /**
+     * Create a PBRTextureAttribute for the given type and populate it with
+     * the texture and TexCoordInfo
+     */
+    private PBRTextureAttribute getTextureAttribute(long type, Texture texture, TexCoordInfo texCoord) {
+        PBRTextureAttribute attr = new PBRTextureAttribute(type, texture);
+        attr.uvIndex = texCoord.uvIndex;
+        attr.offsetU = texCoord.offsetU;
+        attr.offsetV = texCoord.offsetV;
+        attr.scaleU = texCoord.scaleU;
+        attr.scaleV = texCoord.scaleV;
+        attr.rotationUV = texCoord.rotationUV;
+        return attr;
     }
 
     public float getRoughness() {

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/TexCoordInfo.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/TexCoordInfo.java
@@ -1,0 +1,36 @@
+package com.mbrlabs.mundus.commons.assets;
+
+/**
+ * Storage for UV related Texture info.
+ *
+ * @author JamesTKhan
+ * @version July 20, 2022
+ */
+public class TexCoordInfo {
+    public final String PROP_UV;
+    public final String PROP_OFFSET_U;
+    public final String PROP_OFFSET_V;
+    public final String PROP_SCALE_U;
+    public final String PROP_SCALE_V;
+    public final String PROP_ROTATION_UV;
+
+    public String property;
+    public int uvIndex = 0;
+    public float offsetU = 0;
+    public float offsetV = 0;
+    public float scaleU = 1;
+    public float scaleV = 1;
+    public float rotationUV = 0;
+
+    public TexCoordInfo(String property) {
+        this.property = property;
+
+        // Generate props based on given property string (diffuse.uvIndex, etc..)
+        PROP_UV = property + ".uvIndex";
+        PROP_OFFSET_U = property + ".offsetU";
+        PROP_OFFSET_V = property + ".offsetV";
+        PROP_SCALE_U = property + ".scaleU";
+        PROP_SCALE_V = property + ".scaleV";
+        PROP_ROTATION_UV = property + ".rotationUV";
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -630,6 +630,12 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
         props.setProperty(MaterialAsset.PROP_SHADOW_BIAS, mat.shadowBias.toString())
         props.setProperty(MaterialAsset.PROP_CULL_FACE, mat.cullFace.toString())
 
+        setTexCoordInfo(props, mat.diffuseTexCoord)
+        setTexCoordInfo(props, mat.normalTexCoord)
+        setTexCoordInfo(props, mat.emissiveTexCoord)
+        setTexCoordInfo(props, mat.metallicRoughnessTexCoord)
+        setTexCoordInfo(props, mat.occlusionTexCoord)
+
         val fileOutputStream = FileOutputStream(mat.file.file())
         props.store(fileOutputStream, null)
         fileOutputStream.flush()
@@ -637,6 +643,15 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
 
         // save meta file
         metaSaver.save(mat.meta)
+    }
+
+    private fun setTexCoordInfo(props: Properties, texCoordInfo: TexCoordInfo) {
+        props.setProperty(texCoordInfo.PROP_UV, texCoordInfo.uvIndex.toString())
+        props.setProperty(texCoordInfo.PROP_OFFSET_U, texCoordInfo.offsetU.toString())
+        props.setProperty(texCoordInfo.PROP_OFFSET_V, texCoordInfo.offsetV.toString())
+        props.setProperty(texCoordInfo.PROP_SCALE_U, texCoordInfo.scaleU.toString())
+        props.setProperty(texCoordInfo.PROP_SCALE_V, texCoordInfo.scaleV.toString())
+        props.setProperty(texCoordInfo.PROP_ROTATION_UV, texCoordInfo.rotationUV.toString())
     }
 
     private fun saveWaterAsset(asset: WaterAsset) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/ModelImporter.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/ModelImporter.kt
@@ -24,6 +24,7 @@ import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute
 import com.badlogic.gdx.graphics.g3d.attributes.IntAttribute
 import com.mbrlabs.mundus.commons.assets.MaterialAsset
 import com.mbrlabs.mundus.commons.assets.TextureAsset
+import com.mbrlabs.mundus.commons.assets.TexCoordInfo
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.registry.Registry
 import com.mbrlabs.mundus.editor.events.SettingsChangedEvent
@@ -129,6 +130,7 @@ class ModelImporter(private val registry: Registry) : SettingsChangedEvent.Setti
                 assetManager,
                 materialToUse.id,
                 PBRTextureAttribute.BaseColorTexture)
+            populateTextureCoordInfo(PBRTextureAttribute.BaseColorTexture, materialToUse, materialAssetToPopulate.diffuseTexCoord)
         }
 
         if (materialToUse.has(PBRTextureAttribute.NormalTexture)) {
@@ -138,6 +140,7 @@ class ModelImporter(private val registry: Registry) : SettingsChangedEvent.Setti
                 materialToUse.id,
                 PBRTextureAttribute.NormalTexture
             )
+            populateTextureCoordInfo(PBRTextureAttribute.NormalTexture, materialToUse, materialAssetToPopulate.normalTexCoord)
         }
 
         if (materialToUse.has(PBRTextureAttribute.EmissiveTexture)) {
@@ -147,6 +150,7 @@ class ModelImporter(private val registry: Registry) : SettingsChangedEvent.Setti
                 materialToUse.id,
                 PBRTextureAttribute.EmissiveTexture
             )
+            populateTextureCoordInfo(PBRTextureAttribute.EmissiveTexture, materialToUse, materialAssetToPopulate.emissiveTexCoord)
         }
 
         if (materialToUse.has(PBRTextureAttribute.MetallicRoughnessTexture)) {
@@ -156,6 +160,7 @@ class ModelImporter(private val registry: Registry) : SettingsChangedEvent.Setti
                 materialToUse.id,
                 PBRTextureAttribute.MetallicRoughnessTexture
             )
+            populateTextureCoordInfo(PBRTextureAttribute.MetallicRoughnessTexture, materialToUse, materialAssetToPopulate.metallicRoughnessTexCoord)
         }
 
         if (materialToUse.has(PBRTextureAttribute.OcclusionTexture)) {
@@ -165,6 +170,7 @@ class ModelImporter(private val registry: Registry) : SettingsChangedEvent.Setti
                 materialToUse.id,
                 PBRTextureAttribute.OcclusionTexture
             )
+            populateTextureCoordInfo(PBRTextureAttribute.OcclusionTexture, materialToUse, materialAssetToPopulate.occlusionTexCoord)
         }
 
         // Float attributes
@@ -187,6 +193,19 @@ class ModelImporter(private val registry: Registry) : SettingsChangedEvent.Setti
             val attr = materialToUse.get(PBRFloatAttribute.NormalScale) as PBRFloatAttribute
             materialAssetToPopulate.normalScale = attr.value
         }
+    }
+
+    /**
+     * Populates the TexCoordInfo POJO with UV data from the attribute
+     */
+    private fun populateTextureCoordInfo(type: Long, materialToUse: Material, texCoordInfo: TexCoordInfo) {
+        val attr = materialToUse.get(type) as PBRTextureAttribute
+        texCoordInfo.uvIndex = attr.uvIndex
+        texCoordInfo.offsetU = attr.offsetU
+        texCoordInfo.offsetV = attr.offsetV
+        texCoordInfo.scaleU = attr.scaleU
+        texCoordInfo.scaleV = attr.scaleV
+        texCoordInfo.rotationUV = attr.rotationUV
     }
 
     /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/ModelComponentWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/ModelComponentWidget.kt
@@ -72,6 +72,10 @@ class ModelComponentWidget(modelComponent: ModelComponent) : ComponentWidget<Mod
 
             mw.material = component.materials[g3dbMatID]
             materialContainer.add(mw).grow().padBottom(20f).row()
+
+            // Calling this here to setup listeners
+            // prevents iteration within iteration issues
+            mw.setupWidgets()
         }
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/MaterialWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/MaterialWidget.kt
@@ -41,6 +41,7 @@ import com.mbrlabs.mundus.editor.assets.AssetTextureFilter
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.assets.AssetPickerDialog
+import com.mbrlabs.mundus.editor.utils.Colors
 
 /**
  * Displays all properties of a material.
@@ -141,6 +142,7 @@ class MaterialWidget : VisTable() {
         defaults().padBottom(4f)
         val table = VisTable()
         table.add(matNameLabel).grow()
+        matNameLabel.color = Colors.TEAL
         table.add<VisTextButton>(matChangedBtn).padLeft(4f).right().row()
         add(table).grow().row()
 


### PR DESCRIPTION
UV attributes were not being imported into Mundus for GLTF models. This fixes that by getting and setting these values on GLTF import
```
    public int uvIndex = 0;
    public float offsetU = 0;
    public float offsetV = 0;
    public float scaleU = 1;
    public float scaleV = 1;
    public float rotationUV = 0;
```

NOTE: A known limitation of gdx-gltf PBR shaders is that it uses UV scale from one of the textures. Separate UV scale per texture type is not supported right now however, this PR adds UV scale props into each material type so that is could be supported later.

Now scaled UV will import into Mundus. Also adds new UI widgets to allow customizing these values. 

![image](https://user-images.githubusercontent.com/28971753/180313160-93e13db5-0589-4b2c-8add-3070eaa0b4bc.png)
