### PR TITLE
Debug/Wireframe render modes and Keyboard Shortcuts window

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
@@ -44,9 +44,9 @@ public abstract class CullableComponent extends AbstractComponent {
     private final static Vector3 tmpScale = new Vector3();
     private static DirectionalLight directionalLight;
 
-    public final Vector3 center = new Vector3();
-    public final Vector3 dimensions = new Vector3();
-    public float radius;
+    protected final Vector3 center = new Vector3();
+    protected final Vector3 dimensions = new Vector3();
+    protected float radius;
 
     // Is it offscreen?
     protected boolean isCulled = false;
@@ -106,6 +106,18 @@ public abstract class CullableComponent extends AbstractComponent {
         center.scl(tmpScale);
         dimensions.scl(tmpScale);
         radius = dimensions.len() / 2f;
+    }
+
+    public Vector3 getCenter() {
+        return center;
+    }
+
+    public Vector3 getDimensions() {
+        return dimensions;
+    }
+
+    public float getRadius() {
+        return radius;
     }
 
     public boolean isCulled() {

--- a/commons/src/main/com/mbrlabs/mundus/commons/utils/DebugRenderer.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/utils/DebugRenderer.java
@@ -1,0 +1,116 @@
+package com.mbrlabs.mundus.commons.utils;
+
+import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.Disposable;
+import com.mbrlabs.mundus.commons.scene3d.GameObject;
+import com.mbrlabs.mundus.commons.scene3d.components.Component;
+import com.mbrlabs.mundus.commons.scene3d.components.CullableComponent;
+import com.mbrlabs.mundus.commons.scene3d.components.ModelComponent;
+import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent;
+import com.mbrlabs.mundus.commons.scene3d.components.WaterComponent;
+
+/**
+ * Simple debug renderer that only renders bounding boxes of {@link CullableComponent}
+ *  which are used for frustum culling.
+ *
+ * @author JamesTKhan
+ * @version July 25, 2022
+ */
+public class DebugRenderer implements Renderer, Disposable {
+    private static final Vector3 tmpPos = new Vector3();
+    private static final Vector3 tmpCenter = new Vector3();
+
+    private final ShapeRenderer shapeRenderer;
+    private final boolean ownsShapeRenderer;
+
+    private ShapeRenderer.ShapeType shapeType = ShapeRenderer.ShapeType.Line;
+
+    public DebugRenderer() {
+        shapeRenderer = new ShapeRenderer();
+        ownsShapeRenderer = true;
+    }
+
+    public DebugRenderer(ShapeRenderer shapeRenderer) {
+        this.shapeRenderer = shapeRenderer;
+        ownsShapeRenderer = false;
+    }
+
+    public void setShapeType(ShapeRenderer.ShapeType shapeType) {
+        this.shapeType = shapeType;
+    }
+
+    @Override
+    public void begin(Camera camera) {
+        shapeRenderer.begin(shapeType);
+        shapeRenderer.setProjectionMatrix(camera.combined);
+    }
+
+    @Override
+    public void render(Array<GameObject> gameObjects) {
+        for (GameObject object : gameObjects) {
+            render(object);
+        }
+    }
+
+    @Override
+    public void render(GameObject go) {
+        if (!go.active) return;
+
+        for (Component component : go.getComponents()) {
+
+            // Only CullableComponents have bounds info available right now.
+            if (!(component instanceof CullableComponent)) {
+                continue;
+            }
+
+            CullableComponent cullableComponent = (CullableComponent) component;
+            go.getPosition(tmpPos);
+            tmpCenter.set(cullableComponent.getCenter());
+            tmpPos.add(tmpCenter);
+
+            shapeRenderer.setColor(getColor(component));
+            shapeRenderer.box(
+                    tmpPos.x - (cullableComponent.getDimensions().x / 2),
+                    tmpPos.y - (cullableComponent.getDimensions().y / 2),
+                    tmpPos.z + (cullableComponent.getDimensions().z / 2),
+                    cullableComponent.getDimensions().x,
+                    cullableComponent.getDimensions().y,
+                    cullableComponent.getDimensions().z);
+            shapeRenderer.point(tmpCenter.x, tmpCenter.y, tmpCenter.z);
+        }
+
+        if (go.getChildren() == null) return;
+
+        for (GameObject child : go.getChildren()) {
+            render(child);
+        }
+
+    }
+
+    @Override
+    public void end() {
+        shapeRenderer.end();
+    }
+
+    protected Color getColor(Component component) {
+        if (component instanceof ModelComponent) {
+            return Color.RED;
+        } else if (component instanceof TerrainComponent) {
+            return Color.GREEN;
+        } else if (component instanceof WaterComponent) {
+            return Color.NAVY;
+        }
+        return Color.WHITE;
+    }
+
+    @Override
+    public void dispose() {
+        if (ownsShapeRenderer) {
+            shapeRenderer.dispose();
+        }
+    }
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/utils/Renderer.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/utils/Renderer.java
@@ -1,0 +1,40 @@
+package com.mbrlabs.mundus.commons.utils;
+
+import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.utils.Array;
+import com.mbrlabs.mundus.commons.scene3d.GameObject;
+
+/**
+ * Renderer interface for whatever usage, like DebugRenderer.
+ *
+ * Ex.
+ * renderer.begin(camera);
+ * renderer.render(gameObject);
+ * renderer.end;
+ *
+ * @author JamesTKhan
+ * @version July 25, 2022
+ */
+public interface Renderer {
+
+    /**
+     * Called before rendering
+     * @param camera the camera to render to
+     */
+    void begin(Camera camera);
+
+    /**
+     * Render a single game object
+     */
+    void render(GameObject gameObject);
+
+    /**
+     * Render a list of gameObjects
+     */
+    void render(Array<GameObject> gameObjects);
+
+    /**
+     * Called at the end of rendering
+     */
+    void end();
+}

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -14,6 +14,8 @@
 - Added tracking per project for Last Open Directory on File Choosers
 - Added terrain smoothing brush
 - Added configurable camera settings Window -> Settings -> Camera
+- Added Keyboard Shortcuts dialog
+- Added Basic debug and wireframe render modes
 - Update water shader to fade out water foam over distance, to minimize ugly 1 pixel white lines from a distance.
 - Fix broken checkbox to set game objects to active or inactive
 - Fix File Choosers stored favorites under the wrong key name

--- a/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
@@ -22,8 +22,10 @@ import com.badlogic.gdx.backends.lwjgl3.Lwjgl3WindowAdapter
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.g3d.ModelBatch
 import com.badlogic.gdx.graphics.g3d.ModelInstance
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer
 import com.badlogic.gdx.utils.GdxRuntimeException
 import com.mbrlabs.mundus.commons.shaders.MundusPBRShaderProvider
+import com.mbrlabs.mundus.commons.utils.DebugRenderer
 import com.mbrlabs.mundus.commons.utils.ShaderUtils
 import com.mbrlabs.mundus.editor.core.project.ProjectContext
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
@@ -46,6 +48,7 @@ import net.mgsx.gltf.scene3d.scene.SceneRenderableSorter
 import net.mgsx.gltf.scene3d.shaders.PBRDepthShaderProvider
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.FilenameUtils
+import org.lwjgl.opengl.GL11
 
 /**
  * @author Marcus Brummer
@@ -67,6 +70,8 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
     private lateinit var toolManager: ToolManager
     private lateinit var gizmoManager: GizmoManager
     private lateinit var glProfiler: MundusGLProfiler
+    private lateinit var shapeRenderer: ShapeRenderer
+    private lateinit var debugRenderer: DebugRenderer
 
     override fun create() {
         Mundus.registerEventListener(this)
@@ -78,7 +83,10 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
         toolManager = Mundus.inject()
         gizmoManager = Mundus.inject()
         glProfiler = Mundus.inject()
+        shapeRenderer = Mundus.inject()
         setupInput()
+
+        debugRenderer = DebugRenderer(shapeRenderer)
 
         // TODO dispose this
         val axesModel = UsefulMeshs.createAxes()
@@ -132,11 +140,21 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
 
         UI.sceneWidget.setCam(context.currScene.cam)
         UI.sceneWidget.setRenderer {
+            val renderWireframe = projectManager.current().renderWireframe
+            val renderDebug = projectManager.current().renderDebug
 
             glProfiler.resume()
             sg.update()
+            if (renderWireframe) GL11.glPolygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_LINE)
             scene.render()
+            if (renderWireframe) GL11.glPolygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_FILL)
             glProfiler.pause()
+
+            if (renderDebug) {
+                debugRenderer.begin(scene.cam)
+                debugRenderer.render(sg.gameObjects)
+                debugRenderer.end()
+            }
 
             toolManager.render()
             gizmoManager.render()
@@ -202,6 +220,7 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
     }
 
     override fun dispose() {
+        debugRenderer.dispose()
         Mundus.dispose()
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectContext.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectContext.java
@@ -48,6 +48,9 @@ public class ProjectContext implements Disposable {
     public EditorAssetManager assetManager;
     public MundusPreferencesManager projectPref;
 
+    public boolean renderDebug = false;
+    public boolean renderWireframe = false;
+
     private int idProvider;
 
     /** set by kryo when project is loaded. do not use this */

--- a/editor/src/main/com/mbrlabs/mundus/editor/input/ShortcutController.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/input/ShortcutController.kt
@@ -33,6 +33,9 @@ class ShortcutController(registry: Registry, private val projectManager: Project
 
     private var isCtrlPressed = false
 
+    /**
+     * Updates here should also be reflected in the KeyboardShortcutsDialog
+     */
     override fun keyDown(code: Int): Boolean {
         val keycode = convertKeycode(code)
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/input/ShortcutController.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/input/ShortcutController.kt
@@ -76,6 +76,10 @@ class ShortcutController(registry: Registry, private val projectManager: Project
         } else if (keycode == Input.Keys.F) {
             toolManager.activateTool(toolManager.selectionTool)
             UI.toolbar.updateActiveToolButton()
+        } else if (keycode == Input.Keys.F2) {
+            projectManager.current().renderDebug = !projectManager.current().renderDebug
+        } else if (keycode == Input.Keys.F3) {
+            projectManager.current().renderWireframe = !projectManager.current().renderWireframe
         }
 
         return false

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/UI.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/UI.kt
@@ -38,6 +38,7 @@ import com.mbrlabs.mundus.editor.ui.modules.dialogs.DirectionalLightsDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.ExitDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.ExportDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.FogDialog
+import com.mbrlabs.mundus.editor.ui.modules.dialogs.KeyboardShortcutsDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.LoadingProjectDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.NewProjectDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.ShadowSettingsDialog
@@ -100,6 +101,7 @@ object UI : Stage(ScreenViewport()) {
     var shadowSettingsDialog: ShadowSettingsDialog = ShadowSettingsDialog()
     var addComponentDialog: AddComponentDialog = AddComponentDialog()
     val versionDialog: VersionDialog = VersionDialog()
+    val keyboardShortcuts: KeyboardShortcutsDialog = KeyboardShortcutsDialog()
     val exitDialog: ExitDialog = ExitDialog()
 
     // styles

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/KeyboardShortcutsDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/KeyboardShortcutsDialog.kt
@@ -1,0 +1,61 @@
+package com.mbrlabs.mundus.editor.ui.modules.dialogs
+
+import com.kotcrab.vis.ui.widget.VisTable
+
+/**
+ * @author JamesTKhan
+ * @version July 26, 2022
+ */
+class KeyboardShortcutsDialog : BaseDialog("Keyboard Shortcuts") {
+
+    private lateinit var root: VisTable
+
+    init {
+        setupUI()
+    }
+
+    private fun setupUI() {
+        root = VisTable()
+        root.defaults().pad(6f)
+
+        val shortcutTableOne = VisTable()
+        shortcutTableOne.defaults().pad(4f)
+
+        addShortcut("W", "Move Forward", shortcutTableOne)
+        addShortcut("S", "Move Back", shortcutTableOne)
+        addShortcut("A", "Strafe Left", shortcutTableOne)
+        addShortcut("D", "Strafe Right", shortcutTableOne)
+        addShortcut("Q", "Move Up", shortcutTableOne)
+        addShortcut("E", "Move Down", shortcutTableOne)
+        addShortcut("Hold Right Click", "Look Around", shortcutTableOne)
+        addShortcut("Scroll", "Zoom forward/backward", shortcutTableOne)
+        addShortcut("Hold Shift", "Camera Panning", shortcutTableOne)
+        addShortcut("F8", "Toggle Fullscreen 3d", shortcutTableOne)
+
+        root.add(shortcutTableOne).top()
+        root.addSeparator(true)
+
+        val shortcutTableTwo = VisTable()
+        shortcutTableTwo.defaults().pad(4f)
+
+        addShortcut("CTRL+Z", "Undo", shortcutTableTwo)
+        addShortcut("CTRL+Y", "Redo", shortcutTableTwo)
+        addShortcut("CTRL+S", "Save Project", shortcutTableTwo)
+        addShortcut("CTRL+T", "Translate Tool", shortcutTableTwo)
+        addShortcut("CTRL+R", "Rotate Tool", shortcutTableTwo)
+        addShortcut("CTRL+G", "Scale Tool", shortcutTableTwo)
+        addShortcut("CTRL+F", "Select Tool", shortcutTableTwo)
+        addShortcut("CTRL+F2", "Debug Render Mode", shortcutTableTwo)
+        addShortcut("CTRL+F3", "Wireframe Mode", shortcutTableTwo)
+
+        root.add(shortcutTableTwo).top()
+        add(root)
+    }
+
+    private fun addShortcut(key: String, desc: String, table: VisTable) {
+        table.add(key).left()
+        table.addSeparator(true)
+        table.add(desc).left().row()
+        table.addSeparator().colspan(3)
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/WindowMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/WindowMenu.kt
@@ -31,10 +31,12 @@ class WindowMenu : Menu("Window") {
 
     val settings = MenuItem("Settings")
     private val versionInfo = MenuItem("Version Info")
+    private val keyboardShortcuts = MenuItem("Keyboard Shortcuts")
 
     init {
         settings.setShortcut(Input.Keys.CONTROL_LEFT, Input.Keys.ALT_LEFT, Input.Keys.S)
         addItem(settings)
+        addItem(keyboardShortcuts)
         addItem(versionInfo)
 
         settings.addListener(object : ClickListener() {
@@ -46,6 +48,12 @@ class WindowMenu : Menu("Window") {
         versionInfo.addListener(object : ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 UI.showDialog(UI.versionDialog)
+            }
+        })
+
+        keyboardShortcuts.addListener(object : ClickListener() {
+            override fun clicked(event: InputEvent?, x: Float, y: Float) {
+                UI.showDialog(UI.keyboardShortcuts)
             }
         })
     }


### PR DESCRIPTION
Adds a debug render mode (shows model/terrain/water's bounds) and a wire frame mode.

Also adds shortcut keys dialog

![image](https://user-images.githubusercontent.com/28971753/180927418-977544cb-ea8b-4c73-b5b4-acb96b7d9f4a.png)

![image](https://user-images.githubusercontent.com/28971753/180927464-7d8c79ff-021d-4337-9445-e18d15c8181e.png)
![image](https://user-images.githubusercontent.com/28971753/180927517-8e8a7567-d270-4fa4-806c-63d5edcdd692.png)

