### PR TITLE
(Draft) Asynchronous project loading editor + runtime

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/Asset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/Asset.java
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.commons.assets;
 
+import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.Disposable;
 import com.mbrlabs.mundus.commons.assets.meta.Meta;
@@ -73,9 +74,14 @@ public abstract class Asset implements Disposable, AssetUsage {
     /**
      * Loads the asset.
      *
-     * Loads the asset from disk and creates it.
+     * Loads the asset from disk synchronously and creates it.
      */
     public abstract void load();
+
+    /**
+     * Loads the asset using the given asset manager, usually after asynchronous project load.
+     */
+    public abstract void load(AssetManager assetManager);
 
     /**
      * Resolves all dependencies of this asset.

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/AssetManager.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/AssetManager.java
@@ -17,15 +17,31 @@ package com.mbrlabs.mundus.commons.assets;
 
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.assets.loaders.TextureLoader;
+import com.badlogic.gdx.assets.loaders.resolvers.AbsoluteFileHandleResolver;
+import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
 import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.UBJsonReader;
 import com.mbrlabs.mundus.commons.assets.meta.Meta;
 import com.mbrlabs.mundus.commons.assets.meta.MetaFileParseException;
 import com.mbrlabs.mundus.commons.assets.meta.MetaLoader;
+import com.mbrlabs.mundus.commons.g3d.MG3dModelLoader;
+import com.mbrlabs.mundus.commons.terrain.Terrain;
+import com.mbrlabs.mundus.commons.terrain.TerrainLoader;
+import com.mbrlabs.mundus.commons.utils.FileFormatUtils;
+import net.mgsx.gltf.loaders.glb.GLBAssetLoader;
+import net.mgsx.gltf.loaders.gltf.GLTFAssetLoader;
+import net.mgsx.gltf.scene3d.scene.SceneAsset;
 
 import java.io.File;
 import java.io.FileFilter;
+import java.nio.file.FileSystemLoopException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -41,9 +57,12 @@ public class AssetManager implements Disposable {
     private static final String TAG = AssetManager.class.getSimpleName();
 
     protected FileHandle rootFolder;
+    protected FileHandle[] metaFiles;
+    protected final MetaLoader metaLoader = new MetaLoader();
 
     protected Array<Asset> assets;
     protected Map<String, Asset> assetIndex;
+    protected com.badlogic.gdx.assets.AssetManager gdxAssetManager;
 
     // Tracks the highest bone count out of all loaded model assets
     public int maxNumBones = 0;
@@ -58,6 +77,14 @@ public class AssetManager implements Disposable {
         this.rootFolder = assetsFolder;
         this.assets = new Array<>();
         this.assetIndex = new HashMap<>();
+    }
+
+    /**
+     * The Mundus AssetManager class encapsulates the libGDX AssetManager, mostly
+     * for async loading
+     */
+    public com.badlogic.gdx.assets.AssetManager getGdxAssetManager() {
+        return gdxAssetManager;
     }
 
     /**
@@ -157,21 +184,24 @@ public class AssetManager implements Disposable {
     /**
      * Loads all assets in the project's asset folder.
      *
-     * @param listener
-     *            informs about current loading progress
      * @param isRuntime
      *            is this called by the runtime or editor (runtime requires different file logic)
-     * @throws AssetNotFoundException
-     *             if a meta file points to a non existing asset
      * @throws MetaFileParseException
      *             if a meta file can't be parsed
      */
-    public void loadAssets(AssetLoadingListener listener, boolean isRuntime) throws AssetNotFoundException, MetaFileParseException {
-        final MetaLoader metaLoader = new MetaLoader();
+    public void loadAssets(boolean isRuntime) throws MetaFileParseException {
 
         String[] files;
         FileHandle fileList;
-        FileHandle[] metaFiles;
+
+        if (isRuntime) {
+            // assets.txt has relative/internal paths
+            gdxAssetManager = new com.badlogic.gdx.assets.AssetManager(new InternalFileHandleResolver());
+        } else {
+            // For the editor, we get all files in the assets directory and absolute paths via rootFolder.list()
+            // which has the added benefit of detecting assets not in the assets.txt file
+            gdxAssetManager = new com.badlogic.gdx.assets.AssetManager(new AbsoluteFileHandleResolver());
+        }
 
         if (isRuntime && Gdx.app.getType() == Application.ApplicationType.Desktop) {
             // Desktop applications cannot use .list() for internal jar files.
@@ -197,12 +227,92 @@ public class AssetManager implements Disposable {
             metaFiles = rootFolder.list(metaFileFilter);
         }
 
-        // load assets
+        // Set loaders
+        gdxAssetManager.setLoader(Terrain.class, ".terra", new TerrainLoader());
+        gdxAssetManager.setLoader(SceneAsset.class, ".gltf", new GLTFAssetLoader());
+        gdxAssetManager.setLoader(SceneAsset.class, ".glb", new GLBAssetLoader());
+        gdxAssetManager.setLoader(Model.class, ".g3db", new MG3dModelLoader(new UBJsonReader()));
+
+        // Queue files for async loading into LibGDX's assetManager
         for (FileHandle meta : metaFiles) {
-            Asset asset = loadAsset(metaLoader.load(meta));
-            if (listener != null) {
-                listener.onLoad(asset, assets.size, metaFiles.length);
-            }
+            Meta m = metaLoader.load(meta);
+            queueAssetForLoad(m);
+        }
+    }
+
+    protected void queueAssetForLoad(Meta m) {
+        String filePath = m.getFile().pathWithoutExtension();
+        switch (m.getType()) {
+            case TEXTURE:
+                // These are hard coded for now
+                TextureLoader.TextureParameter param = new TextureLoader.TextureParameter();
+                param.genMipMaps = true;
+                param.minFilter = Texture.TextureFilter.MipMapLinearNearest;
+                param.magFilter = Texture.TextureFilter.Linear;
+
+                gdxAssetManager.load(filePath, Texture.class, param);
+                break;
+            case PIXMAP_TEXTURE:
+                gdxAssetManager.load(filePath, Pixmap.class);
+                break;
+            case MODEL:
+                if (FileFormatUtils.isG3DB(filePath)) {
+                    gdxAssetManager.load(filePath, Model.class);
+                } else if (FileFormatUtils.isGLTF(filePath)) {
+                    gdxAssetManager.load(filePath, SceneAsset.class);
+                } else if (FileFormatUtils.isGLB(filePath)) {
+                    gdxAssetManager.load(filePath, SceneAsset.class);
+                } else {
+                    throw new GdxRuntimeException("Unsupported 3D model");
+                }
+                break;
+            case TERRAIN:
+                TerrainLoader.TerrainParameter terrainParameter = new TerrainLoader.TerrainParameter(m.getTerrain());
+                gdxAssetManager.load(filePath, Terrain.class, terrainParameter);
+            case MATERIAL:
+                // loads synchronously
+                break;
+            case WATER:
+                // loads synchronously
+                break;
+            case SKYBOX:
+                // loads synchronously
+                break;
+        }
+    }
+
+    /**
+     * Should be called each frame until it returns true
+     * which indicates that assets are loaded.
+     *
+     * @return boolean indicating if asynchronous loading is complete
+     */
+    public boolean continueLoading() throws MetaFileParseException, AssetNotFoundException {
+        boolean complete = gdxAssetManager.update(17);
+        if (complete) {
+            finalizeLoad();
+        }
+        return complete;
+    }
+
+    /**
+     * Returns a progress value between 0.0 and 1.0 representing the percentage loaded.
+     * @return progress percentage
+     */
+    public float getProgress() {
+        return gdxAssetManager.getProgress();
+    }
+
+    /**
+     * Call to finalize the loading process.
+     */
+    public void finalizeLoad() throws AssetNotFoundException, MetaFileParseException {
+        // Ensure loading is complete before continuing
+        gdxAssetManager.finishLoading();
+
+        // finalize loading of Mundus assets
+        for (FileHandle meta : metaFiles) {
+            loadAsset(metaLoader.load(meta));
         }
 
         // resolve material assets
@@ -222,10 +332,6 @@ public class AssetManager implements Disposable {
             }
             asset.resolveDependencies(assetIndex);
             asset.applyDependencies();
-        }
-
-        if(listener != null) {
-            listener.onFinish(assets.size);
         }
     }
 
@@ -262,8 +368,6 @@ public class AssetManager implements Disposable {
      *             if a meta file points to a non existing asset
      */
     public Asset loadAsset(Meta meta) throws AssetNotFoundException {
-        // get handle to asset
-     //   String assetPath = meta.getFile().pathWithoutExtension();
         FileHandle assetFile = meta.getFile().sibling(meta.getFile().nameWithoutExtension());
 
         // check if asset exists
@@ -305,13 +409,13 @@ public class AssetManager implements Disposable {
 
     private Asset loadSkyboxAsset(Meta meta, FileHandle assetFile) {
         SkyboxAsset asset = new SkyboxAsset(meta, assetFile);
-        asset.load();
+        asset.load(gdxAssetManager);
         return asset;
     }
 
     private MaterialAsset loadMaterialAsset(Meta meta, FileHandle assetFile) {
         MaterialAsset asset = new MaterialAsset(meta, assetFile);
-        asset.load();
+        asset.load(gdxAssetManager);
         return asset;
     }
 
@@ -320,40 +424,41 @@ public class AssetManager implements Disposable {
         // TODO parse special texture instead of always setting them
         asset.setTileable(true);
         asset.generateMipmaps(true);
-        asset.load();
+        asset.load(gdxAssetManager);
         return asset;
     }
 
     private TerrainAsset loadTerrainAsset(Meta meta, FileHandle assetFile) {
         TerrainAsset asset = new TerrainAsset(meta, assetFile);
-        asset.load();
+        asset.load(gdxAssetManager);
         return asset;
     }
 
     private PixmapTextureAsset loadPixmapTextureAsset(Meta meta, FileHandle assetFile) {
         PixmapTextureAsset asset = new PixmapTextureAsset(meta, assetFile);
-        asset.load();
+        asset.load(gdxAssetManager);
         return asset;
     }
 
     private ModelAsset loadModelAsset(Meta meta, FileHandle assetFile) {
         ModelAsset asset = new ModelAsset(meta, assetFile);
-        asset.load();
+        asset.load(gdxAssetManager);
         return asset;
     }
 
     private WaterAsset loadWaterAsset(Meta meta, FileHandle assetFile) {
         WaterAsset asset = new WaterAsset(meta, assetFile);
-        asset.load();
+        asset.load(gdxAssetManager);
         return asset;
     }
 
     @Override
     public void dispose() {
+        Gdx.app.log(TAG, "Disposing assets...");
         for (Asset asset : assets) {
             asset.dispose();
-            Gdx.app.log(TAG, "Disposing asset: " + asset);
         }
+        Gdx.app.log(TAG, "Assets disposed");
         assets.clear();
         assetIndex.clear();
     }

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/MaterialAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/MaterialAsset.java
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.commons.assets;
 
+import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
@@ -163,6 +164,12 @@ public class MaterialAsset extends Asset {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    @Override
+    public void load(AssetManager assetManager) {
+        // No async loading for materials right now
+        load();
     }
 
     private void populateTexCoordInfo(TexCoordInfo texCoordInfo) {

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/ModelAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/ModelAsset.java
@@ -15,6 +15,7 @@
  */
 package com.mbrlabs.mundus.commons.assets;
 
+import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.g3d.Material;
 import com.badlogic.gdx.graphics.g3d.Model;
@@ -27,6 +28,7 @@ import com.mbrlabs.mundus.commons.utils.FileFormatUtils;
 import com.mbrlabs.mundus.commons.utils.ModelUtils;
 import net.mgsx.gltf.loaders.glb.GLBLoader;
 import net.mgsx.gltf.loaders.gltf.GLTFLoader;
+import net.mgsx.gltf.scene3d.scene.SceneAsset;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -69,15 +71,21 @@ public class ModelAsset extends Asset {
         } else {
             throw new GdxRuntimeException("Unsupported 3D model");
         }
-
-        // Update bone count for model
-        if (meta != null && meta.getModel() != null) {
-            //This is to support models armatures being update after initial import
-            // as well as backwards compatability for projects existing prior to getting bone counts on import.
-            meta.getModel().setNumBones(ModelUtils.getBoneCount(model));
-        }
-
+        updateBoneCount();
      }
+
+    @Override
+    public void load(AssetManager assetManager) {
+        Object modelObj = assetManager.get(meta.getFile().pathWithoutExtension());
+        if (modelObj instanceof SceneAsset) {
+            model = ((SceneAsset) modelObj).scene.model;
+        } else if (modelObj instanceof Model) {
+            model = (Model) modelObj;
+        } else {
+            throw new GdxRuntimeException("Unsupported 3D model");
+        }
+        updateBoneCount();
+    }
 
     @Override
     public void resolveDependencies(Map<String, Asset> assets) {
@@ -122,5 +130,14 @@ public class ModelAsset extends Asset {
             }
         }
         return false;
+    }
+
+    private void updateBoneCount() {
+        // Update bone count for model
+        if (meta != null && meta.getModel() != null) {
+            //This is to support models armatures being updated after initial import
+            // as well as backwards compatability for projects existing prior to getting bone counts on import.
+            meta.getModel().setNumBones(ModelUtils.getBoneCount(model));
+        }
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/PixmapTextureAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/PixmapTextureAsset.java
@@ -17,6 +17,7 @@
 package com.mbrlabs.mundus.commons.assets;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
@@ -49,6 +50,12 @@ public class PixmapTextureAsset extends Asset {
     @Override
     public void load() {
         pixmap = new Pixmap(file);
+        texture = new Texture(pixmap);
+    }
+
+    @Override
+    public void load(AssetManager assetManager) {
+        pixmap = assetManager.get(meta.getFile().pathWithoutExtension());
         texture = new Texture(pixmap);
     }
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/SkyboxAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/SkyboxAsset.java
@@ -1,5 +1,6 @@
 package com.mbrlabs.mundus.commons.assets;
 
+import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.PropertiesUtils;
@@ -70,6 +71,12 @@ public class SkyboxAsset extends Asset {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    @Override
+    public void load(AssetManager assetManager) {
+        // No async loading for skybox right now
+        load();
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/TerrainAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/TerrainAsset.java
@@ -17,18 +17,17 @@ package com.mbrlabs.mundus.commons.assets;
 
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.assets.loaders.resolvers.AbsoluteFileHandleResolver;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.utils.FloatArray;
 import com.mbrlabs.mundus.commons.assets.meta.Meta;
 import com.mbrlabs.mundus.commons.terrain.SplatMap;
 import com.mbrlabs.mundus.commons.terrain.SplatTexture;
 import com.mbrlabs.mundus.commons.terrain.Terrain;
+import com.mbrlabs.mundus.commons.terrain.TerrainLoader;
 import com.mbrlabs.mundus.commons.terrain.TerrainTexture;
 
-import java.io.DataInputStream;
-import java.io.EOFException;
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -213,28 +212,18 @@ public class TerrainAsset extends Asset {
 
     @Override
     public void load() {
-        // load height data from terra file
-        final FloatArray floatArray = new FloatArray();
+        // Load a terrain synchronously
+        FileHandle terraFile = Gdx.files.absolute(meta.getFile().pathWithoutExtension());
+        TerrainLoader.TerrainParameter param = new TerrainLoader.TerrainParameter(meta.getTerrain());
+        TerrainLoader terrainLoader = new TerrainLoader(new AbsoluteFileHandleResolver());
+        terrainLoader.loadAsync(null, null, terraFile, param);
+        terrain = terrainLoader.loadSync(null, null, terraFile, param);
+    }
 
-        DataInputStream is;
-        try {
-            is = new DataInputStream(file.read());
-            while (is.available() > 0) {
-                floatArray.add(is.readFloat());
-            }
-            is.close();
-        } catch (EOFException e) {
-            // e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
-            return;
-        }
-        data = floatArray.toArray();
-
-        terrain = new Terrain(meta.getTerrain().getSize(), data);
-        terrain.init();
-        terrain.updateUvScale(new Vector2(meta.getTerrain().getUv(), meta.getTerrain().getUv()));
-        terrain.update();
+    @Override
+    public void load(AssetManager assetManager) {
+        terrain = assetManager.get(meta.getFile().pathWithoutExtension());
+        data = terrain.heightData;
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/TextureAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/TextureAsset.java
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.commons.assets;
 
+import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Texture;
 import com.mbrlabs.mundus.commons.assets.meta.Meta;
@@ -60,6 +61,15 @@ public class TextureAsset extends Asset implements TextureProvider {
         } else {
             texture = new Texture(file);
         }
+
+        if (tileable) {
+            texture.setWrap(Texture.TextureWrap.Repeat, Texture.TextureWrap.Repeat);
+        }
+    }
+
+    @Override
+    public void load(AssetManager assetManager) {
+        texture = assetManager.get(meta.getFile().pathWithoutExtension());
 
         if (tileable) {
             texture.setWrap(Texture.TextureWrap.Repeat, Texture.TextureWrap.Repeat);

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/WaterAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/WaterAsset.java
@@ -1,5 +1,6 @@
 package com.mbrlabs.mundus.commons.assets;
 
+import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.utils.ObjectMap;
@@ -76,6 +77,12 @@ public class WaterAsset extends Asset {
             e.printStackTrace();
         }
 
+    }
+
+    @Override
+    public void load(AssetManager assetManager) {
+        // No async loading for water right now
+        load();
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaLoader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaLoader.java
@@ -86,7 +86,6 @@ public class MetaLoader {
         final JsonValue materials = jsonModel.get(MetaModel.JSON_DEFAULT_MATERIALS);
 
         for(final JsonValue mat : materials) {
-            System.out.println(mat.name);
             final String g3dbID = mat.name;
             final String assetUUID = materials.getString(g3dbID);
             model.getDefaultMaterials().put(g3dbID, assetUUID);

--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/TerrainLoader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/TerrainLoader.java
@@ -1,0 +1,91 @@
+package com.mbrlabs.mundus.commons.terrain;
+
+import com.badlogic.gdx.assets.AssetDescriptor;
+import com.badlogic.gdx.assets.AssetLoaderParameters;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.assets.loaders.AsynchronousAssetLoader;
+import com.badlogic.gdx.assets.loaders.FileHandleResolver;
+import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.FloatArray;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.mbrlabs.mundus.commons.assets.meta.MetaTerrain;
+
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+
+/**
+ * Loads Mundus Terrain objects via meta and .terra file data.
+ * @author JamesTKhan
+ * @version July 24, 2022
+ */
+public class TerrainLoader extends AsynchronousAssetLoader<Terrain, TerrainLoader.TerrainParameter> {
+
+    private Terrain terrain = null;
+
+    public TerrainLoader() {
+        this(new InternalFileHandleResolver());
+    }
+
+    public TerrainLoader(FileHandleResolver resolver) {
+        super(resolver);
+    }
+
+    @Override
+    public Array<AssetDescriptor> getDependencies(String fileName, FileHandle file, TerrainParameter parameter) {
+        if (parameter == null) {
+            throw new GdxRuntimeException("TerrainLoader requires parameters");
+        }
+
+        if (parameter.metaTerrain == null) {
+            throw new GdxRuntimeException("MetaTerrain is required for TerrainLoader");
+        }
+        return null;
+    }
+
+    @Override
+    public void loadAsync(AssetManager manager, String fileName, FileHandle file, TerrainParameter parameter) {
+        terrain = null;
+
+        final FloatArray floatArray = new FloatArray();
+
+        // load height data from terra file
+        DataInputStream is;
+        try {
+            is = new DataInputStream(file.read());
+            while (is.available() > 0) {
+                floatArray.add(is.readFloat());
+            }
+            is.close();
+        } catch (EOFException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new GdxRuntimeException("Error reading terra file: " + file.name());
+        }
+        terrain = new Terrain(parameter.metaTerrain.getSize(), floatArray.toArray());
+        terrain.updateUvScale(new Vector2(parameter.metaTerrain.getUv(), parameter.metaTerrain.getUv()));
+    }
+
+    @Override
+    public Terrain loadSync(AssetManager manager, String fileName, FileHandle file, TerrainParameter parameter) {
+        terrain.init();
+        terrain.update();
+
+        Terrain terrain = this.terrain;
+        this.terrain = null;
+        return terrain;
+    }
+
+    static public class TerrainParameter extends AssetLoaderParameters<Terrain> {
+        public TerrainParameter(MetaTerrain metaTerrain) {
+            this.metaTerrain = metaTerrain;
+        }
+
+        /** Required to create the terrain properly **/
+        public MetaTerrain metaTerrain = null;
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -24,7 +24,17 @@ import com.badlogic.gdx.graphics.PixmapIO
 import com.badlogic.gdx.utils.Array
 import com.badlogic.gdx.utils.ObjectSet
 import com.kotcrab.vis.ui.util.dialog.Dialogs
-import com.mbrlabs.mundus.commons.assets.*
+import com.mbrlabs.mundus.commons.assets.Asset
+import com.mbrlabs.mundus.commons.assets.AssetManager
+import com.mbrlabs.mundus.commons.assets.AssetType
+import com.mbrlabs.mundus.commons.assets.MaterialAsset
+import com.mbrlabs.mundus.commons.assets.ModelAsset
+import com.mbrlabs.mundus.commons.assets.PixmapTextureAsset
+import com.mbrlabs.mundus.commons.assets.SkyboxAsset
+import com.mbrlabs.mundus.commons.assets.TerrainAsset
+import com.mbrlabs.mundus.commons.assets.TexCoordInfo
+import com.mbrlabs.mundus.commons.assets.TextureAsset
+import com.mbrlabs.mundus.commons.assets.WaterAsset
 import com.mbrlabs.mundus.commons.assets.meta.Meta
 import com.mbrlabs.mundus.commons.assets.meta.MetaTerrain
 import com.mbrlabs.mundus.commons.scene3d.GameObject
@@ -32,6 +42,7 @@ import com.mbrlabs.mundus.commons.scene3d.components.AssetUsage
 import com.mbrlabs.mundus.commons.utils.FileFormatUtils
 import com.mbrlabs.mundus.commons.water.WaterFloatAttribute
 import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.Mundus.postEvent
 import com.mbrlabs.mundus.editor.core.EditorScene
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.LogEvent
@@ -40,7 +51,11 @@ import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.utils.Log
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.FilenameUtils
-import java.io.*
+import java.io.BufferedOutputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
 import java.util.*
 
 /**
@@ -105,7 +120,7 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
     @Throws(IOException::class, AssetAlreadyExistsException::class)
     fun createNewMetaFile(file: FileHandle, type: AssetType): Meta {
         if (file.exists()) {
-            Mundus.postEvent(LogEvent(LogType.ERROR, "Tried to create new Meta File that already exists: " + file.name()))
+            postEvent(LogEvent(LogType.ERROR, "Tried to create new Meta File that already exists: " + file.name()))
             throw AssetAlreadyExistsException()
         }
 
@@ -124,6 +139,39 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
     }
 
     /**
+     * Override this to check if any standard assets are missing
+     * after project load. If so, it recreates the missing standard assets
+     */
+    override fun finalizeLoad() {
+        super.finalizeLoad()
+
+        // create standard assets if any are missing, to support backwards compatibility when new standard assets are added
+        val reloadedAssets: Array<Asset> = createStandardAssets()
+
+        // If a standard asset was missing we reload assets, now that the standard asset is recreated.
+        if (!reloadedAssets.isEmpty) {
+            postEvent(
+                LogEvent(
+                    LogType.WARN, "A standard asset was missing. Reloading assets: " + reloadedAssets.toString() +
+                            " This only occurs if a standard asset was deleted."
+                )
+            )
+            for (asset in reloadedAssets) {
+                queueAssetForLoad(asset.meta)
+            }
+
+            gdxAssetManager.finishLoading()
+
+            for (asset in reloadedAssets) {
+                asset.load(gdxAssetManager)
+                addAsset(asset)
+                asset.resolveDependencies(assetIndex)
+                asset.applyDependencies()
+            }
+        }
+    }
+
+    /**
      * Creates a couple of standard assets if they are not present.
      *
      * Creates a couple of standard assets in the current project, that should
@@ -131,46 +179,38 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
      *
      * Returns true if an asset was loaded.
      */
-    fun createStandardAssets(): Boolean {
+    fun createStandardAssets(): Array<Asset> {
+        val createdAssets = Array<Asset>()
         try {
 
-            var assetLoaded = false
-
             if (findAssetByID(STANDARD_ASSET_TEXTURE_CHESSBOARD) == null) {
-                createStandardAsset(STANDARD_ASSET_TEXTURE_CHESSBOARD, "standardAssets/chessboard.png")
-                assetLoaded = true
+                createdAssets.add(createStandardAsset(STANDARD_ASSET_TEXTURE_CHESSBOARD, "standardAssets/chessboard.png"))
             }
-
             if (findAssetByID(STANDARD_ASSET_TEXTURE_DUDV) == null) {
-                createStandardAsset(STANDARD_ASSET_TEXTURE_DUDV, "standardAssets/dudv.png")
-                assetLoaded = true
+                createdAssets.add(createStandardAsset(STANDARD_ASSET_TEXTURE_DUDV, "standardAssets/dudv.png"))
             }
-
             if (findAssetByID(STANDARD_ASSET_TEXTURE_WATER_NORMAL) == null) {
-                createStandardAsset(STANDARD_ASSET_TEXTURE_WATER_NORMAL, "standardAssets/waterNormal.png")
-                assetLoaded = true
+                createdAssets.add(createStandardAsset(STANDARD_ASSET_TEXTURE_WATER_NORMAL, "standardAssets/waterNormal.png"))
             }
-
             if (findAssetByID(STANDARD_ASSET_TEXTURE_WATER_FOAM) == null) {
-                createStandardAsset(STANDARD_ASSET_TEXTURE_WATER_FOAM, "standardAssets/waterFoam.png")
-                assetLoaded = true
+                createdAssets.add(createStandardAsset(STANDARD_ASSET_TEXTURE_WATER_FOAM, "standardAssets/waterFoam.png"))
             }
-
-            return assetLoaded
+            return createdAssets
 
         } catch (e: Exception) {
             e.printStackTrace()
-            return false
+            return createdAssets
         }
 
     }
 
-    private fun createStandardAsset(id: String, path: String) {
+    private fun createStandardAsset(id: String, path: String): TextureAsset {
         val textureAsset = getOrCreateTextureAsset(Gdx.files.internal(path))
         assetIndex.remove(textureAsset.id)
         textureAsset.meta.uuid = id
         assetIndex[textureAsset.id] = textureAsset
         metaSaver.save(textureAsset.meta)
+        return textureAsset
     }
 
     /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectContext.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectContext.java
@@ -42,6 +42,9 @@ public class ProjectContext implements Disposable {
     public String path;
     public String name;
 
+    // Has the project completed loading?
+    public boolean loaded = false;
+
     public Array<String> scenes;
     public EditorScene currScene;
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -53,6 +53,7 @@ import com.mbrlabs.mundus.editor.events.ProjectChangedEvent;
 import com.mbrlabs.mundus.editor.events.SceneChangedEvent;
 import com.mbrlabs.mundus.editor.scene3d.components.PickableComponent;
 import com.mbrlabs.mundus.editor.shader.Shaders;
+import com.mbrlabs.mundus.editor.ui.UI;
 import com.mbrlabs.mundus.editor.utils.Log;
 import com.mbrlabs.mundus.editor.utils.SkyboxBuilder;
 
@@ -77,6 +78,7 @@ public class ProjectManager implements Disposable {
     public static final String PROJECT_EXTENSION = "pro";
 
     private ProjectContext currentProject;
+    private ProjectContext loadingProject;
     private Registry registry;
     private KryoManager kryoManager;
     private ModelBatch modelBatch;
@@ -96,6 +98,26 @@ public class ProjectManager implements Disposable {
      */
     public ProjectContext current() {
         return currentProject;
+    }
+
+    public ProjectContext loadingProject() {
+        return loadingProject;
+    }
+
+    public boolean isLoading() {
+        if (loadingProject == null) {
+            return false;
+        }
+
+        return !loadingProject.loaded;
+    }
+
+    public boolean isLoaded() {
+        if (loadingProject == null) {
+            return false;
+        }
+
+        return loadingProject.loaded;
     }
 
     /**
@@ -220,7 +242,8 @@ public class ProjectManager implements Disposable {
         ref.setPath(absolutePath);
 
         try {
-            ProjectContext context = loadProject(ref);
+            ProjectContext context = startAsyncProjectLoad(ref);
+            UI.INSTANCE.toggleLoadingScreen(true);
             ref.setName(context.name);
             registry.getProjects().add(ref);
             kryoManager.saveRegistry(registry);
@@ -230,57 +253,11 @@ public class ProjectManager implements Disposable {
         }
     }
 
-    /**
-     * Loads the project context for a project.
-     *
-     * This does not open to that project, it only loads it.
-     *
-     * @param ref
-     *            project reference to the project
-     * @return loaded project context
-     * @throws FileNotFoundException
-     *             if project can't be found
-     */
-    public ProjectContext loadProject(ProjectRef ref)
-            throws FileNotFoundException, MetaFileParseException, AssetNotFoundException {
-        ProjectContext context = kryoManager.loadProjectContext(ref);
-        context.path = ref.getPath();
-
-        // load assets
-        loadAssets(ref, context);
-
-        // create standard assets if any are missing, to support backwards compatibility when new standard assets are added
-        boolean standardAssetReloaded = context.assetManager.createStandardAssets();
-
-        // If a standard asset was missing we reload assets, now that the standard asset is recreated.
-        if (standardAssetReloaded) {
-            Mundus.INSTANCE.postEvent(new LogEvent(LogType.WARN, "A standard asset was missing. Reloading assets." +
-                    " This only occurs if a standard asset was deleted."));
-            loadAssets(ref, context);
-        }
-
-        context.currScene = loadScene(context, context.activeSceneName);
-
-        return context;
-    }
-
-    private void loadAssets(ProjectRef ref, ProjectContext context) throws MetaFileParseException, AssetNotFoundException {
+    private void loadAssets(ProjectRef ref, ProjectContext context) throws MetaFileParseException {
         context.assetManager = new EditorAssetManager(
                 new FileHandle(ref.getPath() + "/" + ProjectManager.PROJECT_ASSETS_DIR));
 
-        context.assetManager.loadAssets(new AssetManager.AssetLoadingListener() {
-            @Override
-            public void onLoad(Asset asset, int progress, int assetCount) {
-                Log.debug(TAG, "Loaded {} asset ({}/{})", asset.getMeta().getType(), progress, assetCount);
-                Mundus.INSTANCE.postEvent(new LogEvent("Loaded " + asset.getMeta().getType() + " asset ("+progress+"/"+assetCount+")"));
-            }
-
-            @Override
-            public void onFinish(int assetCount) {
-                Log.debug(TAG, "Finished loading {} assets", assetCount);
-                Mundus.INSTANCE.postEvent(new LogEvent("Finished loading " + assetCount + " assets"));
-            }
-        }, false);
+        context.assetManager.loadAssets(false);
     }
 
     /**
@@ -333,23 +310,61 @@ public class ProjectManager implements Disposable {
      *
      * @return project context of last project
      */
-    public ProjectContext loadLastProject() {
+    public ProjectContext loadLastProjectAsync() {
         ProjectRef lastOpenedProject = registry.getLastOpenedProject();
         if (lastOpenedProject != null) {
             try {
-                return loadProject(lastOpenedProject);
+                return startAsyncProjectLoad(lastOpenedProject);
             } catch (FileNotFoundException fnf) {
                 Log.error(TAG, fnf.getMessage());
                 fnf.printStackTrace();
-            } catch (AssetNotFoundException anf) {
+            } catch (AssetNotFoundException | MetaFileParseException anf) {
                 Log.error(TAG, anf.getMessage());
-            } catch (MetaFileParseException mfp) {
-                Log.error(TAG, mfp.getMessage());
             }
             return null;
         }
-
         return null;
+    }
+
+    /**
+     * Starts loading the project context for a project.
+     *
+     * This does not open to that project, it only starts the async load process.
+     * {@link #continueLoading()} must be called each frame while loading to continue the loading process.
+     *
+     * @param ref
+     *            project reference to the project
+     * @return initialized but unloaded project context
+     * @throws FileNotFoundException
+     *             if project can't be found
+     */
+    public ProjectContext startAsyncProjectLoad(ProjectRef ref) throws FileNotFoundException, MetaFileParseException, AssetNotFoundException {
+        Log.debug(TAG, "Asynchronous project loading started...");
+        loadingProject = kryoManager.loadProjectContext(ref);
+        loadingProject.path = ref.getPath();
+
+        // Queues up assets for loading
+        loadAssets(ref, loadingProject);
+
+        return loadingProject;
+    }
+
+    public ProjectContext continueLoading() throws FileNotFoundException, MetaFileParseException, AssetNotFoundException {
+        boolean complete = loadingProject.assetManager.continueLoading();
+
+        if (!complete) {
+            return loadingProject;
+        }
+
+        return finalizeLoading();
+    }
+
+    private ProjectContext finalizeLoading() throws FileNotFoundException {
+        Log.debug(TAG, "Asynchronous project loading complete");
+
+        loadingProject.currScene = loadScene(loadingProject, loadingProject.activeSceneName);
+        loadingProject.loaded = true;
+        return loadingProject;
     }
 
     /**
@@ -366,6 +381,11 @@ public class ProjectManager implements Disposable {
                 currentProject.assetManager.deleteNewUnsavedAssets();
             }
             currentProject.dispose();
+        }
+
+        // Null it out now that loading is complete
+        if (context == loadingProject) {
+            loadingProject = null;
         }
 
         currentProject = context;
@@ -559,7 +579,7 @@ public class ProjectManager implements Disposable {
      * Disposes current depth model batch, assigns the new batch and updates the depth batch
      * on the current scene.
      *
-     * @param modelBatch new ModelBatch instance to use
+     * @param depthBatch new ModelBatch instance to use
      */
     public void setDepthBatch(ModelBatch depthBatch) {
         if (this.depthBatch != null) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/UI.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/UI.kt
@@ -16,7 +16,11 @@
 
 package com.mbrlabs.mundus.editor.ui
 
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.graphics.Texture
 import com.badlogic.gdx.scenes.scene2d.Stage
+import com.badlogic.gdx.scenes.scene2d.actions.Actions
+import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.utils.viewport.ScreenViewport
 import com.kotcrab.vis.ui.VisUI
 import com.kotcrab.vis.ui.widget.Separator
@@ -31,7 +35,6 @@ import com.mbrlabs.mundus.editor.preferences.MundusPreferencesManager
 import com.mbrlabs.mundus.editor.ui.modules.MundusToolbar
 import com.mbrlabs.mundus.editor.ui.modules.Outline
 import com.mbrlabs.mundus.editor.ui.modules.StatusBar
-import com.mbrlabs.mundus.editor.ui.modules.dialogs.VersionDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.AddComponentDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.AmbientLightDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.DirectionalLightsDialog
@@ -42,6 +45,7 @@ import com.mbrlabs.mundus.editor.ui.modules.dialogs.LoadingProjectDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.NewProjectDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.ShadowSettingsDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.SkyboxDialog
+import com.mbrlabs.mundus.editor.ui.modules.dialogs.VersionDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.assets.AssetPickerDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.importer.ImportModelDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.importer.ImportTextureDialog
@@ -76,6 +80,7 @@ object UI : Stage(ScreenViewport()) {
 
     // base elements
     private val root: VisTable
+    private val loadingRoot: VisTable
     private var mainContainer: VisTable
     private lateinit var splitPane: MundusSplitPane
     var menuBar: MundusMenuBar
@@ -116,6 +121,13 @@ object UI : Stage(ScreenViewport()) {
         addActor(root)
         root.setFillParent(true)
 
+        loadingRoot = VisTable()
+        val logo = Image(Texture(Gdx.files.internal("icon/logo.png")))
+        loadingRoot.addActor(logo)
+        addActor(loadingRoot)
+
+        logo.addAction(Actions.sequence(Actions.alpha(0.2f)))
+
         mainContainer = VisTable()
         menuBar = MundusMenuBar()
         toolbar = MundusToolbar()
@@ -124,6 +136,17 @@ object UI : Stage(ScreenViewport()) {
         sceneWidget = RenderWidget()
 
         addUIActors()
+    }
+
+    fun toggleLoadingScreen(value: Boolean) {
+        if (value) {
+            root.isVisible = false
+            loadingRoot.isVisible = true
+            loadingRoot.setPosition(Gdx.graphics.width / 2f - (loadingRoot.children.get(0).width / 2f), Gdx.graphics.height / 2f)
+        } else {
+            root.isVisible = true
+            loadingRoot.isVisible = false
+        }
     }
 
     private fun addUIActors() {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/FileMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/FileMenu.kt
@@ -61,8 +61,8 @@ class FileMenu : Menu("File") {
             pro.addListener(object : ClickListener() {
                 override fun clicked(event: InputEvent?, x: Float, y: Float) {
                     try {
-                        val projectContext = projectManager.loadProject(ref)
-                        projectManager.changeProject(projectContext)
+                        projectManager.startAsyncProjectLoad(ref)
+                        UI.toggleLoadingScreen(true)
                     } catch (e: Exception) {
                         e.printStackTrace()
                         Dialogs.showErrorDialog(UI, "Could not open project")


### PR DESCRIPTION
This PR adds asynchronous project loading to both the editor and the runtime. Loading or switching projects now displays a loading bar that updates. 


 Things to test

- [ ] Test creating new project
- [ ] Test importing a project
- [ ] Test creating a project
- [ ] Test model import
- [ ] Test g3d/fbx/ imports
- [ ] Test creation for all asset types