### PR TITLE
Unused Assets Tool

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
@@ -79,7 +79,20 @@ public class Scene implements Disposable {
     protected Vector3 clippingPlaneReflection = new Vector3(0.0f, 1f, 0.0f);
     protected Vector3 clippingPlaneRefraction = new Vector3(0.0f, -1f, 0.0f);
 
+    /**
+     * The default way to instantiate a scene. Use this constructor if you
+     * are using the runtime.
+     */
     public Scene() {
+        this(true);
+    }
+
+    /**
+     * Optionally allow instantiation of a scene without using any OpenGL context
+     * useful for when you need a scene object loaded on a different thread.
+     * @param hasGLContext normally this should be true, false if you are not on main thread
+     */
+    public Scene(boolean hasGLContext) {
         environment = new MundusEnvironment();
         settings = new SceneSettings();
 
@@ -98,9 +111,10 @@ public class Scene implements Disposable {
         environment.getAmbientLight().intensity = 0.8f;
         environment.set(ColorAttribute.createAmbientLight(Color.WHITE));
 
-        initPBR();
-
-        setShadowQuality(ShadowResolution.DEFAULT_SHADOW_RESOLUTION);
+        if (hasGLContext) {
+            initPBR();
+            setShadowQuality(ShadowResolution.DEFAULT_SHADOW_RESOLUTION);
+        }
 
         sceneGraph = new SceneGraph(this);
     }

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/TerrainAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/TerrainAsset.java
@@ -394,6 +394,13 @@ public class TerrainAsset extends Asset {
                     return true;
                 }
             }
+
+            // Check normal maps
+            if (assetToCheck == splatBaseNormal || assetToCheck == splatRNormal ||
+                assetToCheck == splatBNormal || assetToCheck == splatGNormal || assetToCheck == splatANormal) {
+                return true;
+            }
+
         }
 
         return false;

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -17,6 +17,7 @@
 - Added configurable camera settings Window -> Settings -> Camera
 - Added Keyboard Shortcuts dialog
 - Added Basic debug and wireframe render modes
+- Added Utility to clean up unused assets under new Tools menu item
 - Update water shader to fade out water foam over distance, to minimize ugly 1 pixel white lines from a distance.
 - Fix broken checkbox to set game objects to active or inactive
 - Fix File Choosers stored favorites under the wrong key name

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -42,7 +42,6 @@ import com.mbrlabs.mundus.commons.scene3d.components.AssetUsage
 import com.mbrlabs.mundus.commons.utils.FileFormatUtils
 import com.mbrlabs.mundus.commons.water.WaterFloatAttribute
 import com.mbrlabs.mundus.editor.Mundus.postEvent
-import com.mbrlabs.mundus.editor.core.EditorScene
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.LogEvent
 import com.mbrlabs.mundus.editor.events.LogType
@@ -210,6 +209,15 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
         assetIndex[textureAsset.id] = textureAsset
         metaSaver.save(textureAsset.meta)
         return textureAsset
+    }
+
+    private fun getStandardAssets(): Array<Asset> {
+        val standardAssets = Array<Asset>()
+        standardAssets.add(findAssetByID(STANDARD_ASSET_TEXTURE_CHESSBOARD))
+        standardAssets.add(findAssetByID(STANDARD_ASSET_TEXTURE_DUDV))
+        standardAssets.add(findAssetByID(STANDARD_ASSET_TEXTURE_WATER_NORMAL))
+        standardAssets.add(findAssetByID(STANDARD_ASSET_TEXTURE_WATER_FOAM))
+        return standardAssets
     }
 
     /**
@@ -456,9 +464,39 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
     }
 
     /**
-     * Delete the asset from the project
+     * Searches all GameObjects and assets to find assets which are not used.
      */
-    fun deleteAsset(asset: Asset, projectManager: ProjectManager) {
+    fun findUnusedAssets(projectManager: ProjectManager): Array<Asset> {
+        val unusedAssets = Array<Asset>()
+        val standardAssets = getStandardAssets()
+
+        for (i in 0 until assets.size) {
+            val asset = assets[i]
+
+            // Do not consider standard assets as unused even if not currently used
+            if (standardAssets.contains(asset, true)) {
+                continue
+            }
+
+            if (asset is SkyboxAsset) {
+                continue // It is common to have these be unused
+            } else {
+                val objectsUsingAsset = findAssetUsagesInScenes(projectManager, asset)
+                val assetsUsingAsset = findAssetUsagesInAssets(asset)
+
+                if (objectsUsingAsset.isEmpty() && assetsUsingAsset.isEmpty()) {
+                    unusedAssets.add(asset)
+                }
+            }
+        }
+
+        return unusedAssets
+    }
+
+    /**
+     * Delete the asset from the project if no usages are found
+     */
+    fun deleteAssetSafe(asset: Asset, projectManager: ProjectManager) {
         if (asset is SkyboxAsset) {
             val skyboxUsages = findSkyboxUsagesInScenes(projectManager, asset)
             if (skyboxUsages.isNotEmpty()) {
@@ -475,6 +513,13 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
             }
         }
 
+        deleteAsset(asset)
+    }
+
+    /**
+     * Delete asset, does not check if it is being used.
+     */
+    fun deleteAsset(asset: Asset) {
         // continue with deletion
         assets?.removeValue(asset, true)
 
@@ -571,20 +616,24 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
 
         // we check for usages in all scenes
         for (sceneName in projectManager.current().scenes) {
-            val scene = projectManager.loadScene(projectManager.current(), sceneName)
-            checkSceneForAssetUsage(scene, asset, objectsWithAssets)
+            val gameObjects = projectManager.getSceneGameObjects(projectManager.current(), sceneName)
+            checkSceneForAssetUsage(sceneName, gameObjects, asset, objectsWithAssets)
         }
 
         return objectsWithAssets
     }
 
-    private fun checkSceneForAssetUsage(scene: EditorScene?, asset: Asset, objectsWithAssets: HashMap<GameObject, String>) {
-        for (gameObject in scene!!.sceneGraph.gameObjects) {
+    private fun checkSceneForAssetUsage(sceneName: String, gameObjects: Array<GameObject>, asset: Asset, objectsWithAssets: HashMap<GameObject, String>) {
+        for (gameObject in gameObjects) {
             for (component in gameObject.components) {
                 if (component is AssetUsage) {
                     if (component.usesAsset(asset))
-                        objectsWithAssets[gameObject] = scene.name
+                        objectsWithAssets[gameObject] = sceneName
                 }
+            }
+
+            if (gameObject.children != null) {
+                checkSceneForAssetUsage(sceneName, gameObject.children, asset, objectsWithAssets)
             }
         }
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -493,6 +493,8 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
         return unusedAssets
     }
 
+
+
     /**
      * Delete the asset from the project if no usages are found
      */
@@ -595,7 +597,7 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
     /**
      * Searches all assets in the current context for any usages of the given asset
      */
-    private fun findAssetUsagesInAssets(asset: Asset): ArrayList<Asset> {
+    fun findAssetUsagesInAssets(asset: Asset): ArrayList<Asset> {
         val assetsUsingAsset = ArrayList<Asset>()
 
         // Check for dependent assets that are not in scenes
@@ -611,7 +613,7 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
     /**
      * Searches all scenes in the current context for any usages of the given asset
      */
-    private fun findAssetUsagesInScenes(projectManager: ProjectManager, asset: Asset): HashMap<GameObject, String> {
+    fun findAssetUsagesInScenes(projectManager: ProjectManager, asset: Asset): HashMap<GameObject, String> {
         val objectsWithAssets = HashMap<GameObject, String>()
 
         // we check for usages in all scenes

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -29,6 +29,7 @@ import com.mbrlabs.mundus.commons.assets.ModelAsset;
 import com.mbrlabs.mundus.commons.assets.SkyboxAsset;
 import com.mbrlabs.mundus.commons.assets.TextureAsset;
 import com.mbrlabs.mundus.commons.assets.meta.MetaFileParseException;
+import com.mbrlabs.mundus.commons.dto.GameObjectDTO;
 import com.mbrlabs.mundus.commons.dto.SceneDTO;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
@@ -41,6 +42,7 @@ import com.mbrlabs.mundus.editor.Mundus;
 import com.mbrlabs.mundus.editor.assets.AssetAlreadyExistsException;
 import com.mbrlabs.mundus.editor.assets.EditorAssetManager;
 import com.mbrlabs.mundus.editor.core.EditorScene;
+import com.mbrlabs.mundus.editor.core.converter.GameObjectConverter;
 import com.mbrlabs.mundus.editor.core.converter.SceneConverter;
 import com.mbrlabs.mundus.editor.core.kryo.KryoManager;
 import com.mbrlabs.mundus.editor.core.registry.ProjectRef;
@@ -478,6 +480,26 @@ public class ProjectManager implements Disposable {
 
         return scene;
     }
+
+    /**
+     * Get all GameObjects from a scene. Partially loads the scene fast without using GL context
+     * so this can be called on a separate thread.
+     */
+    public Array<GameObject> getSceneGameObjects(ProjectContext context, String sceneName) throws FileNotFoundException {
+        SceneDTO sceneDTO = SceneManager.loadScene(context, sceneName);
+
+        Scene scene = new Scene(false);
+        for (GameObjectDTO descriptor : sceneDTO.getGameObjects()) {
+            scene.sceneGraph.addGameObject(GameObjectConverter.convert(descriptor, scene.sceneGraph, context.assetManager.getAssetMap()));
+        }
+        for (GameObject go : scene.sceneGraph.getGameObjects()) {
+            initGameObject(context, go);
+        }
+
+        scene.dispose();
+        return scene.sceneGraph.getGameObjects();
+    }
+
 
     /**
      * Loads and opens scene

--- a/editor/src/main/com/mbrlabs/mundus/editor/events/AssetDeletedEvent.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/events/AssetDeletedEvent.kt
@@ -1,0 +1,14 @@
+package com.mbrlabs.mundus.editor.events
+
+/**
+ * @author JamesTKhan
+ * @version July 28, 2022
+ */
+class AssetDeletedEvent  {
+
+    interface AssetDeletedListener {
+        @Subscribe
+        fun onAssetDeleted(event: AssetDeletedEvent)
+    }
+
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AssetCleanUpDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AssetCleanUpDialog.kt
@@ -47,6 +47,7 @@ class AssetCleanUpDialog : BaseDialog(TITLE) {
     private val root = VisTable()
     private val loadingRoot = VisTable()
     private val pane = AutoFocusScrollPane(assetTable)
+    private val selectAll = VisCheckBox("Select All")
     private val yes = VisTextButton("Yes")
     private val cancel = VisTextButton("Cancel")
 
@@ -85,6 +86,7 @@ class AssetCleanUpDialog : BaseDialog(TITLE) {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 for (actor in assetTable.children) {
                     if (actor is VisCheckBox && actor.isChecked) {
+                        if (actor.userObject == null) continue
                         val asset = actor.userObject as Asset
                         projectManager.current().assetManager.deleteAsset(asset)
                     }
@@ -101,11 +103,34 @@ class AssetCleanUpDialog : BaseDialog(TITLE) {
             }
         })
 
+        selectAll.addListener(object : ClickListener() {
+            override fun clicked(event: InputEvent?, x: Float, y: Float) {
+                super.clicked(event, x, y)
+                val checkAll = selectAll.isChecked
+                for (ckBox in assetTable.children) {
+                    if (ckBox is VisCheckBox) {
+                        ckBox.isChecked = checkAll
+                    }
+                }
+            }
+        })
+
     }
 
     fun setAssetsToDelete(assets: Array<Asset>) {
         loadingRoot.remove()
         add(root).top().left()
+
+        if (assets.isEmpty) {
+            assetTable.add("No unused assets found.")
+            pack()
+            centerWindow()
+            return
+        }
+
+        assetTable.add(selectAll).left().row()
+        selectAll.isChecked = true
+        assetTable.addSeparator()
         for (asset in assets) {
             val ckBox = VisCheckBox(asset.name)
             ckBox.userObject = asset

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AssetCleanUpDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AssetCleanUpDialog.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2016. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.editor.ui.modules.dialogs
+
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.scenes.scene2d.InputEvent
+import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
+import com.badlogic.gdx.utils.Array
+import com.kotcrab.vis.ui.widget.VisCheckBox
+import com.kotcrab.vis.ui.widget.VisLabel
+import com.kotcrab.vis.ui.widget.VisTable
+import com.kotcrab.vis.ui.widget.VisTextButton
+import com.mbrlabs.mundus.commons.assets.Asset
+import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.core.project.ProjectManager
+import com.mbrlabs.mundus.editor.events.AssetDeletedEvent
+import com.mbrlabs.mundus.editor.ui.UI
+import com.mbrlabs.mundus.editor.ui.widgets.AutoFocusScrollPane
+
+/**
+ * Dialog to display the Asset Clean Up utility
+ *
+ * @author JamesTKhan
+ * @version July 29, 2022
+ */
+class AssetCleanUpDialog : BaseDialog(TITLE) {
+
+    companion object {
+        private const val TITLE = "Asset Clean Up"
+    }
+
+    private val assetTable = VisTable()
+    private val root = VisTable()
+    private val loadingRoot = VisTable()
+    private val pane = AutoFocusScrollPane(assetTable)
+    private val yes = VisTextButton("Yes")
+    private val cancel = VisTextButton("Cancel")
+
+    private val projectManager: ProjectManager = Mundus.inject()
+
+    init {
+        setupUI()
+        setupListeners()
+        pane.fadeScrollBars = false
+    }
+
+    private fun setupUI() {
+        loadingRoot.add(VisLabel("Searching...")).left().pad(10f).row()
+        add(loadingRoot).top().left()
+
+        root.padTop(6f).padRight(6f).padBottom(10f)
+        root.defaults().pad(4f)
+
+        val label = VisLabel()
+        label.wrap = true
+        label.setText("Note: Running this process multiple times may find more assets due to removals from previous scan.")
+
+        root.add(label).grow().left().colspan(2).padBottom(10f).row()
+
+        val deleteLabel = VisLabel("This cannot be undone. Delete selected assets?")
+        deleteLabel.color.set(Color.SCARLET)
+        root.add(deleteLabel).grow().left().colspan(2).padBottom(10f).row()
+        root.add(pane).colspan(2).fillX().expandX().row()
+        root.add(yes).expandX().fillX()
+        root.add(cancel).expandX().fillX()
+    }
+
+    private fun setupListeners() {
+        // Yes
+        yes.addListener(object : ClickListener() {
+            override fun clicked(event: InputEvent?, x: Float, y: Float) {
+                for (actor in assetTable.children) {
+                    if (actor is VisCheckBox && actor.isChecked) {
+                        val asset = actor.userObject as Asset
+                        projectManager.current().assetManager.deleteAsset(asset)
+                    }
+                }
+                Mundus.postEvent(AssetDeletedEvent())
+                close()
+            }
+        })
+
+        // cancel
+        cancel.addListener(object : ClickListener() {
+            override fun clicked(event: InputEvent?, x: Float, y: Float) {
+                close()
+            }
+        })
+
+    }
+
+    fun setAssetsToDelete(assets: Array<Asset>) {
+        loadingRoot.remove()
+        add(root).top().left()
+        for (asset in assets) {
+            val ckBox = VisCheckBox(asset.name)
+            ckBox.userObject = asset
+            ckBox.isChecked = true
+            assetTable.add(ckBox).left().row()
+        }
+        pack()
+
+        if (height > UI.viewport.screenHeight * .4f) {
+            this.height = UI.viewport.screenHeight * .4f
+        }
+
+        centerWindow()
+    }
+
+    override fun close() {
+        super.close()
+        clearChildren()
+    }
+
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/assets/AssetPickerDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/assets/AssetPickerDialog.kt
@@ -21,7 +21,6 @@ import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
 import com.badlogic.gdx.utils.Array
 import com.kotcrab.vis.ui.util.adapter.SimpleListAdapter
-import com.kotcrab.vis.ui.widget.ListView
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
 import com.mbrlabs.mundus.commons.assets.Asset
@@ -32,6 +31,7 @@ import com.mbrlabs.mundus.editor.events.AssetImportEvent
 import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.BaseDialog
+import com.mbrlabs.mundus.editor.ui.widgets.AutoFocusListView
 
 /**
  * A filterable list of materials.
@@ -52,7 +52,7 @@ class AssetPickerDialog : BaseDialog(AssetPickerDialog.TITLE),
 
     private val root = VisTable()
     private val listAdapter = SimpleListAdapter(Array<Asset>())
-    private val list = ListView(listAdapter)
+    private val list = AutoFocusListView(listAdapter)
     private val noneBtn = VisTextButton("None / Remove old asset")
 
     private var filter: AssetFilter? = null

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/LogBar.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/LogBar.kt
@@ -3,17 +3,20 @@ package com.mbrlabs.mundus.editor.ui.modules.dock
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.Input
 import com.badlogic.gdx.graphics.Color
-import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.InputListener
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
-import com.kotcrab.vis.ui.widget.*
+import com.kotcrab.vis.ui.widget.MenuItem
+import com.kotcrab.vis.ui.widget.PopupMenu
+import com.kotcrab.vis.ui.widget.VisLabel
+import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.tabbedpane.Tab
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.events.LogEvent
 import com.mbrlabs.mundus.editor.events.LogType
 import com.mbrlabs.mundus.editor.ui.UI
+import com.mbrlabs.mundus.editor.ui.widgets.AutoFocusScrollPane
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -24,7 +27,7 @@ class LogBar : Tab(false, false), LogEvent.LogEventListener {
 
     private val root = VisTable()
     private val logTable = VisTable()
-    private val pane = VisScrollPane(logTable)
+    private val pane = AutoFocusScrollPane(logTable)
 
     private val logOpsMenu = PopupMenu()
     private val clearLogsButton = MenuItem("Clear Logs")
@@ -67,17 +70,6 @@ class LogBar : Tab(false, false), LogEvent.LogEventListener {
                     logOpsMenu.showMenu(UI, Gdx.input.x.toFloat(),
                             (Gdx.graphics.height - Gdx.input.y).toFloat())
                 }
-            }
-
-            override fun enter(event: InputEvent, x: Float, y: Float, pointer: Int, fromActor: Actor?) {
-                // Give scroll focus to pane automatically when mouse enters
-                UI.scrollFocus = pane
-            }
-
-            override fun exit(event: InputEvent, x: Float, y: Float, pointer: Int, toActor: Actor?) {
-                // Only clear focus if the exit to another actor is NOT an actor within the LogBars root
-                if (toActor?.isDescendantOf(root) != true)
-                    UI.scrollFocus = null
             }
         })
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/ProfilingBar.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/ProfilingBar.kt
@@ -3,11 +3,11 @@ package com.mbrlabs.mundus.editor.ui.modules.dock
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.kotcrab.vis.ui.widget.VisLabel
-import com.kotcrab.vis.ui.widget.VisScrollPane
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.tabbedpane.Tab
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.profiling.MundusGLProfiler
+import com.mbrlabs.mundus.editor.ui.widgets.AutoFocusScrollPane
 
 /**
  * @author JamesTKhan
@@ -19,7 +19,7 @@ class ProfilingBar : Tab(false, false) {
 
     private val root = VisTable()
     private val profileTable = VisTable()
-    private val pane = VisScrollPane(profileTable)
+    private val pane = AutoFocusScrollPane(profileTable)
 
     private val fpsLabel = VisLabel("FPS : ")
     private val fps = VisLabel()

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/assets/AssetsDock.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/assets/AssetsDock.kt
@@ -42,6 +42,7 @@ import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.*
 import com.mbrlabs.mundus.editor.ui.UI
+import com.mbrlabs.mundus.editor.ui.widgets.AutoFocusScrollPane
 
 
 /**
@@ -51,6 +52,7 @@ import com.mbrlabs.mundus.editor.ui.UI
 class AssetsDock : Tab(false, false),
         ProjectChangedEvent.ProjectChangedListener,
         AssetImportEvent.AssetImportListener,
+        AssetDeletedEvent.AssetDeletedListener,
         GameObjectSelectedEvent.GameObjectSelectedListener,
         FullScreenEvent.FullScreenEventListener {
 
@@ -126,7 +128,7 @@ class AssetsDock : Tab(false, false),
         deleteAsset.addListener(object : ClickListener() {
             override fun clicked(event: InputEvent, x: Float, y: Float) {
                 currentSelection?.asset?.let {
-                    projectManager.current().assetManager.deleteAsset(it, projectManager)
+                    projectManager.current().assetManager.deleteAssetSafe(it, projectManager)
                     reloadAssets()
                 }
             }
@@ -152,7 +154,7 @@ class AssetsDock : Tab(false, false),
         }
     }
 
-    private fun reloadAssets() {
+    fun reloadAssets() {
         filesView.clearChildren()
         val projectContext = projectManager.current()
         for (asset in projectContext.assetManager.assets) {
@@ -165,7 +167,7 @@ class AssetsDock : Tab(false, false),
     }
 
     private fun createScrollPane(actor: Actor, disableX: Boolean): VisScrollPane {
-        val scrollPane = VisScrollPane(actor)
+        val scrollPane = AutoFocusScrollPane(actor)
         scrollPane.setFadeScrollBars(false)
         scrollPane.setScrollingDisabled(disableX, false)
         return scrollPane
@@ -184,6 +186,10 @@ class AssetsDock : Tab(false, false),
     }
 
     override fun onAssetImported(event: AssetImportEvent) {
+        reloadAssets()
+    }
+
+    override fun onAssetDeleted(event: AssetDeletedEvent) {
         reloadAssets()
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/AssetInspector.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/AssetInspector.kt
@@ -19,10 +19,13 @@ package com.mbrlabs.mundus.editor.ui.modules.inspector
 import com.badlogic.gdx.utils.Align
 import com.kotcrab.vis.ui.widget.VisTable
 import com.mbrlabs.mundus.commons.assets.*
+import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.ui.modules.inspector.assets.MaterialAssetInspectorWidget
 import com.mbrlabs.mundus.editor.ui.modules.inspector.assets.ModelAssetInspectorWidget
 import com.mbrlabs.mundus.editor.ui.modules.inspector.assets.TerrainAssetInspectorWidget
 import com.mbrlabs.mundus.editor.ui.modules.inspector.assets.TextureAssetInspectorWidget
+import com.mbrlabs.mundus.editor.ui.modules.inspector.assets.UsedByAssetInspectorWidget
 
 /**
  * @author Marcus Brummer
@@ -34,11 +37,14 @@ class AssetInspector : VisTable() {
     private val modelWidget = ModelAssetInspectorWidget()
     private val textureWidget = TextureAssetInspectorWidget()
     private val terrainWidget = TerrainAssetInspectorWidget()
+    private val usedByWidget = UsedByAssetInspectorWidget()
+    private var projectManager: ProjectManager
 
     var asset: Asset? = null
         set(value) {
             field = value
             clear()
+
             if (value is MaterialAsset) {
                 add(materialWidget).growX().row()
                 materialWidget.setMaterial(value)
@@ -52,11 +58,15 @@ class AssetInspector : VisTable() {
                 add(terrainWidget).growX().row()
                 terrainWidget.setTerrainAsset(value)
             }
+
+            add(usedByWidget).padTop(10f).growX().row()
+            usedByWidget.setAsset(asset, projectManager)
         }
 
     init {
         align(Align.top)
         pad(7f)
+        projectManager = Mundus.inject()
     }
 
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/Inspector.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/Inspector.kt
@@ -16,20 +16,16 @@
 
 package com.mbrlabs.mundus.editor.ui.modules.inspector
 
-import com.badlogic.gdx.scenes.scene2d.Actor
-import com.badlogic.gdx.scenes.scene2d.InputEvent
-import com.badlogic.gdx.scenes.scene2d.InputListener
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.utils.Align
 import com.kotcrab.vis.ui.widget.VisLabel
-import com.kotcrab.vis.ui.widget.VisScrollPane
 import com.kotcrab.vis.ui.widget.VisTable
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.events.AssetSelectedEvent
 import com.mbrlabs.mundus.editor.events.ComponentAddedEvent
 import com.mbrlabs.mundus.editor.events.GameObjectModifiedEvent
 import com.mbrlabs.mundus.editor.events.GameObjectSelectedEvent
-import com.mbrlabs.mundus.editor.ui.UI
+import com.mbrlabs.mundus.editor.ui.widgets.AutoFocusScrollPane
 import com.mbrlabs.mundus.editor.utils.Log
 
 /**
@@ -52,7 +48,7 @@ class Inspector : VisTable(),
 
     private var mode = InspectorMode.EMPTY
     private val root = VisTable()
-    private val scrollPane = VisScrollPane(root)
+    private val scrollPane = AutoFocusScrollPane(root)
 
     private val goInspector: GameObjectInspector
     private val assetInspector: AssetInspector
@@ -74,15 +70,6 @@ class Inspector : VisTable(),
         scrollPane.setScrollingDisabled(true, false)
         scrollPane.setFlickScroll(false)
         scrollPane.setFadeScrollBars(false)
-        scrollPane.addListener(object : InputListener() {
-            override fun enter(event: InputEvent?, x: Float, y: Float, pointer: Int, fromActor: Actor?) {
-                UI.scrollFocus = scrollPane
-            }
-
-            override fun exit(event: InputEvent?, x: Float, y: Float, pointer: Int, toActor: Actor?) {
-                UI.scrollFocus = null
-            }
-        })
 
         add<ScrollPane>(scrollPane).expand().fill().top()
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/assets/UsedByAssetInspectorWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/assets/UsedByAssetInspectorWidget.kt
@@ -1,0 +1,68 @@
+package com.mbrlabs.mundus.editor.ui.modules.inspector.assets
+
+import com.badlogic.gdx.utils.Align
+import com.kotcrab.vis.ui.widget.VisLabel
+import com.kotcrab.vis.ui.widget.VisTable
+import com.mbrlabs.mundus.commons.assets.Asset
+import com.mbrlabs.mundus.commons.scene3d.GameObject
+import com.mbrlabs.mundus.editor.core.project.ProjectManager
+import com.mbrlabs.mundus.editor.ui.modules.inspector.BaseInspectorWidget
+import com.mbrlabs.mundus.editor.ui.widgets.AutoFocusScrollPane
+
+
+/**
+ * Shows which assets and scenes an Asset is used by.
+ *
+ * @author JamesTKhan
+ * @version July 29, 2022
+ */
+class UsedByAssetInspectorWidget  : BaseInspectorWidget(TITLE) {
+
+    companion object {
+        private val TITLE = "Usages"
+    }
+
+    val root = VisTable()
+    private val scrollPane = AutoFocusScrollPane(root)
+
+    init {
+        isDeletable = false
+        defaults().padBottom(4f)
+        collapsibleContent.add(scrollPane).top().left().growX( ).row()
+    }
+
+    fun setAsset(asset: Asset?, projectManager: ProjectManager) {
+
+        root.clearChildren()
+        if (asset == null) return
+        val usagesInAssets = projectManager.current().assetManager.findAssetUsagesInAssets(asset)
+        val usagesInScenes = projectManager.current().assetManager.findAssetUsagesInScenes(projectManager, asset)
+
+        root.defaults().align(Align.left)
+
+        if (usagesInAssets.isNotEmpty()) {
+            root.add(VisLabel("Used By Assets")).row()
+            root.addSeparator()
+            for (assetUsage in usagesInAssets) {
+                root.add(assetUsage.name).row()
+            }
+        }
+
+        if (usagesInScenes.isNotEmpty()) {
+            root.add(VisLabel("Used in Scenes")).padTop(10f).row()
+            root.addSeparator()
+            for (assetUsage in usagesInScenes) {
+                root.add(assetUsage.value + ": " + assetUsage.key.name).row()
+            }
+        }
+    }
+
+    override fun onDelete() {
+        // can't be deleted
+    }
+
+    override fun setValues(go: GameObject) {
+        // nope
+    }
+
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/assets/UsedByAssetInspectorWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/assets/UsedByAssetInspectorWidget.kt
@@ -41,7 +41,7 @@ class UsedByAssetInspectorWidget  : BaseInspectorWidget(TITLE) {
         root.defaults().align(Align.left)
 
         if (usagesInAssets.isNotEmpty()) {
-            root.add(VisLabel("Used By Assets")).row()
+            root.add(VisLabel("Used by Assets")).row()
             root.addSeparator()
             for (assetUsage in usagesInAssets) {
                 root.add(assetUsage.name).row()

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/MundusMenuBar.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/MundusMenuBar.kt
@@ -35,6 +35,7 @@ class MundusMenuBar : MenuBar() {
     val windowMenu = WindowMenu()
     val assetsMenu = AssetsMenu()
     val environmentMenu = EnvironmentMenu()
+    val toolsMenu = ToolsMenu()
     private val sceneMenu = SceneMenu()
 
     init {
@@ -43,6 +44,7 @@ class MundusMenuBar : MenuBar() {
         addMenu(assetsMenu)
         addMenu(environmentMenu)
         addMenu(sceneMenu)
+        addMenu(toolsMenu)
         addMenu(windowMenu)
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/ToolsMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/ToolsMenu.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.editor.ui.modules.menu
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.scenes.scene2d.InputEvent
+import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
+import com.kotcrab.vis.ui.widget.Menu
+import com.kotcrab.vis.ui.widget.MenuItem
+import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.core.project.ProjectManager
+import com.mbrlabs.mundus.editor.ui.UI
+import com.mbrlabs.mundus.editor.ui.modules.dialogs.AssetCleanUpDialog
+
+/**
+ * @author JamesTKhan
+ * @version July 28, 2022
+ */
+class ToolsMenu : Menu("Tools") {
+
+    private val findUnusedAssets = MenuItem("Asset Clean Up")
+
+    val projectManager: ProjectManager = Mundus.inject()
+
+    init {
+        addItem(findUnusedAssets)
+
+        findUnusedAssets.addListener(object : ClickListener() {
+            override fun clicked(event: InputEvent?, x: Float, y: Float) {
+                val dialog = AssetCleanUpDialog()
+                UI.showDialog(dialog)
+                Thread {
+                    val unusedAssets = projectManager.current().assetManager.findUnusedAssets(projectManager)
+                    Gdx.app.postRunnable {
+                        dialog.setAssetsToDelete(unusedAssets)
+                    }
+                }.start()
+            }
+        })
+    }
+
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/AutoFocusListView.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/AutoFocusListView.kt
@@ -1,0 +1,26 @@
+package com.mbrlabs.mundus.editor.ui.widgets
+
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.InputEvent
+import com.badlogic.gdx.scenes.scene2d.InputListener
+import com.kotcrab.vis.ui.util.adapter.ListAdapter
+import com.kotcrab.vis.ui.widget.ListView
+import com.mbrlabs.mundus.editor.ui.UI
+
+/**
+ * @author JamesTKhan
+ * @version July 28, 2022
+ */
+class AutoFocusListView<ItemT>(adapter: ListAdapter<ItemT>) : ListView<ItemT>(adapter) {
+    init {
+        scrollPane.addListener(object : InputListener() {
+            override fun enter(event: InputEvent?, x: Float, y: Float, pointer: Int, fromActor: Actor?) {
+                UI.scrollFocus = scrollPane
+            }
+
+            override fun exit(event: InputEvent?, x: Float, y: Float, pointer: Int, toActor: Actor?) {
+                UI.scrollFocus = null
+            }
+        })
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/AutoFocusScrollPane.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/AutoFocusScrollPane.kt
@@ -1,0 +1,24 @@
+package com.mbrlabs.mundus.editor.ui.widgets
+
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.InputEvent
+import com.badlogic.gdx.scenes.scene2d.InputListener
+import com.kotcrab.vis.ui.widget.VisScrollPane
+
+/**
+ * @author JamesTKhan
+ * @version July 28, 2022
+ */
+class AutoFocusScrollPane(actor: Actor) : VisScrollPane(actor) {
+    init {
+        addListener(object : InputListener() {
+            override fun enter(event: InputEvent?, x: Float, y: Float, pointer: Int, fromActor: Actor?) {
+                stage.scrollFocus = this@AutoFocusScrollPane
+            }
+
+            override fun exit(event: InputEvent?, x: Float, y: Float, pointer: Int, toActor: Actor?) {
+                stage.scrollFocus = null
+            }
+        })
+    }
+}


### PR DESCRIPTION
1. Adds a tool to detect and delete unused assets as deleting assets manually is painful. Can be activated by going to Tools -> Asset Clean Up in the top bar.

2. Adds a new Usages Inspector widget when clicking on assets in the asset dock which shows all uses of the selected asset in other assets and scenes

3. Update most scroll panes to use new auto focusing scroll pane which detects mouse enter and gives focus to scroll pane without requiring a click. 

![image](https://user-images.githubusercontent.com/28971753/181689896-9868041a-930f-4348-9119-607fbae9a066.png)

![image](https://user-images.githubusercontent.com/28971753/181690130-3fd64809-3ef6-448e-b0e5-299dc43180f0.png)

