### PR TITLE
Dialog window for debug rendering

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
@@ -25,7 +25,6 @@ import com.badlogic.gdx.graphics.OrthographicCamera
 import com.badlogic.gdx.graphics.g3d.ModelBatch
 import com.badlogic.gdx.graphics.g3d.ModelInstance
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer
-import com.badlogic.gdx.utils.GdxRuntimeException
 import com.mbrlabs.mundus.commons.shaders.MundusPBRShaderProvider
 import com.mbrlabs.mundus.commons.utils.DebugRenderer
 import com.mbrlabs.mundus.commons.utils.ShaderUtils
@@ -100,10 +99,7 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
         var context: ProjectContext? = projectManager.loadLastProjectAsync()
         if (context == null) {
             context = createDefaultProject()
-        }
-
-        if(context == null) {
-            throw GdxRuntimeException("Couldn't open a project")
+            projectManager.startAsyncProjectLoad(context!!.path, context)
         }
 
         guiCamera = OrthographicCamera()

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -154,6 +154,7 @@ public class ProjectManager implements Disposable {
         ProjectContext newProjectContext = new ProjectContext(-1);
         newProjectContext.path = path;
         newProjectContext.name = ref.getName();
+        newProjectContext.activeSceneName = DEFAULT_SCENE_NAME;
         newProjectContext.assetManager = new EditorAssetManager(
                 new FileHandle(path + "/" + ProjectManager.PROJECT_ASSETS_DIR));
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/UI.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/UI.kt
@@ -50,6 +50,7 @@ import com.mbrlabs.mundus.editor.ui.modules.dialogs.assets.AssetPickerDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.importer.ImportModelDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.importer.ImportTextureDialog
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.settings.SettingsDialog
+import com.mbrlabs.mundus.editor.ui.modules.dialogs.tools.DebugRenderDialog
 import com.mbrlabs.mundus.editor.ui.modules.dock.DockBar
 import com.mbrlabs.mundus.editor.ui.modules.inspector.Inspector
 import com.mbrlabs.mundus.editor.ui.modules.menu.MundusMenuBar
@@ -106,6 +107,7 @@ object UI : Stage(ScreenViewport()) {
     var addComponentDialog: AddComponentDialog = AddComponentDialog()
     val versionDialog: VersionDialog = VersionDialog()
     val keyboardShortcuts: KeyboardShortcutsDialog = KeyboardShortcutsDialog()
+    val debugRenderDialog: DebugRenderDialog = DebugRenderDialog()
     val exitDialog: ExitDialog = ExitDialog()
 
     // styles

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/tools/AssetCleanUpDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/tools/AssetCleanUpDialog.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.mbrlabs.mundus.editor.ui.modules.dialogs
+package com.mbrlabs.mundus.editor.ui.modules.dialogs.tools
 
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.InputEvent
@@ -29,6 +29,7 @@ import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.AssetDeletedEvent
 import com.mbrlabs.mundus.editor.ui.UI
+import com.mbrlabs.mundus.editor.ui.modules.dialogs.BaseDialog
 import com.mbrlabs.mundus.editor.ui.widgets.AutoFocusScrollPane
 
 /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/tools/DebugRenderDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/tools/DebugRenderDialog.kt
@@ -1,0 +1,49 @@
+package com.mbrlabs.mundus.editor.ui.modules.dialogs.tools
+
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
+import com.kotcrab.vis.ui.widget.VisCheckBox
+import com.kotcrab.vis.ui.widget.VisTable
+import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.core.project.ProjectManager
+import com.mbrlabs.mundus.editor.ui.modules.dialogs.BaseDialog
+import com.mbrlabs.mundus.editor.ui.widgets.ToolTipLabel
+
+class DebugRenderDialog : BaseDialog(TITLE) {
+
+    companion object {
+        private const val TITLE = "Debug Render Options"
+    }
+
+    private val showBoundingBoxes = VisCheckBox(null)
+    private val wireFrameMode = VisCheckBox(null)
+    private val projectManager: ProjectManager = Mundus.inject()
+
+    init {
+        setupUI()
+    }
+
+    private fun setupUI() {
+        val table = VisTable()
+        table.add(ToolTipLabel("Show Bounding Boxes", "Renders boxes around model objects. Useful for debugging frustum culling as" +
+                "\nthe bounding boxes reflect what frustum culling will use when determining to cull an object. Hotkey: CTRL+F2")).left()
+        table.add(showBoundingBoxes).left().padBottom(10f).row()
+
+        table.add(ToolTipLabel("Wireframe Mode", "Uses OpenGL glPolygonMode with GL_LINE to show wireframe.  Hotkey: CTRL+F3")).left()
+        table.add(wireFrameMode).left().padBottom(10f).row()
+
+        add(table)
+
+        showBoundingBoxes.addListener(object : ChangeListener() {
+            override fun changed(event: ChangeEvent?, actor: Actor?) {
+                projectManager.current().renderDebug = !projectManager.current().renderDebug
+            }
+        })
+
+        wireFrameMode.addListener(object : ChangeListener() {
+            override fun changed(event: ChangeEvent?, actor: Actor?) {
+                projectManager.current().renderWireframe = !projectManager.current().renderWireframe
+            }
+        })
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/tools/DebugRenderDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/tools/DebugRenderDialog.kt
@@ -23,6 +23,22 @@ class DebugRenderDialog : BaseDialog(TITLE) {
         setupUI()
     }
 
+    override fun act(delta: Float) {
+        super.act(delta)
+
+        if (projectManager.current().renderWireframe != wireFrameMode.isChecked) {
+            wireFrameMode.setProgrammaticChangeEvents(false)
+            wireFrameMode.toggle()
+            wireFrameMode.setProgrammaticChangeEvents(true)
+        }
+
+        if (projectManager.current().renderDebug != showBoundingBoxes.isChecked) {
+            showBoundingBoxes.setProgrammaticChangeEvents(false)
+            showBoundingBoxes.toggle()
+            showBoundingBoxes.setProgrammaticChangeEvents(true)
+        }
+    }
+
     private fun setupUI() {
         val table = VisTable()
         table.add(ToolTipLabel("Show Bounding Boxes", "Renders boxes around model objects. Useful for debugging frustum culling as" +

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/ToolsMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/ToolsMenu.kt
@@ -24,7 +24,7 @@ import com.kotcrab.vis.ui.widget.MenuItem
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.ui.UI
-import com.mbrlabs.mundus.editor.ui.modules.dialogs.AssetCleanUpDialog
+import com.mbrlabs.mundus.editor.ui.modules.dialogs.tools.AssetCleanUpDialog
 
 /**
  * @author JamesTKhan
@@ -33,11 +33,13 @@ import com.mbrlabs.mundus.editor.ui.modules.dialogs.AssetCleanUpDialog
 class ToolsMenu : Menu("Tools") {
 
     private val findUnusedAssets = MenuItem("Asset Clean Up")
+    private val debugRendering = MenuItem("Debug Render Options")
 
     val projectManager: ProjectManager = Mundus.inject()
 
     init {
         addItem(findUnusedAssets)
+        addItem(debugRendering)
 
         findUnusedAssets.addListener(object : ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
@@ -49,6 +51,12 @@ class ToolsMenu : Menu("Tools") {
                         dialog.setAssetsToDelete(unusedAssets)
                     }
                 }.start()
+            }
+        })
+
+        debugRendering.addListener(object : ClickListener() {
+            override fun clicked(event: InputEvent?, x: Float, y: Float) {
+                UI.showDialog(UI.debugRenderDialog)
             }
         })
     }


### PR DESCRIPTION
Adds a way to toggle existing debug rendering modes via the UI underneath the Tools file option.

Also added a fix to the async load process for fresh installs of Mundus with no existing projects