### PR TITLE
Model caching

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/dto/ModelComponentDTO.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/dto/ModelComponentDTO.java
@@ -26,6 +26,7 @@ public class ModelComponentDTO {
 
     private String modelID;
     private HashMap<String, String> materials; // g3db material id to material asset uuid
+    private boolean useModelCache;
 
     public ModelComponentDTO() {
         materials = new HashMap<>();
@@ -47,4 +48,11 @@ public class ModelComponentDTO {
         this.modelID = modelID;
     }
 
+    public boolean isUseModelCache() {
+        return useModelCache;
+    }
+
+    public void setUseModelCache(boolean useModelCache) {
+        this.useModelCache = useModelCache;
+    }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/ModelCacheManager.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/ModelCacheManager.java
@@ -40,7 +40,11 @@ public class ModelCacheManager implements Disposable {
         }
     }
 
-    protected void rebuildModelCache() {
+    /**
+     * Rebuilds model cache for the current scene. Potentially expensive
+     * depending on the size of the scene and should only be rebuilt when needed.
+     */
+    public void rebuildModelCache() {
         modelCache.begin(scene.cam);
         addModelsToCache(scene.sceneGraph.getGameObjects());
         modelCache.end();
@@ -91,6 +95,21 @@ public class ModelCacheManager implements Disposable {
      */
     public void setModelCacheUpdateInterval(float interval) {
         modelCacheUpdateInterval = interval;
+    }
+
+    /**
+     * Rebuild model cache if given GameObject has a cacheable component.
+     */
+    public static void rebuildIfCached(GameObject go, boolean immediately) {
+        for (int i = 0; i < go.getComponents().size; i++) {
+            if (go.getComponents().get(i) instanceof ModelCacheable) {
+                if (immediately)
+                    go.sceneGraph.scene.modelCacheManager.rebuildModelCache();
+                else
+                    go.sceneGraph.scene.modelCacheManager.requestModelCacheRebuild();
+                break;
+            }
+        }
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/ModelCacheable.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/ModelCacheable.java
@@ -1,0 +1,27 @@
+package com.mbrlabs.mundus.commons.scene3d;
+
+import com.badlogic.gdx.graphics.g3d.ModelInstance;
+
+/**
+ * Indicates the object has a ModelInstance that can be cached.
+ *
+ * @author JamesTKhan
+ * @version August 02, 2022
+ */
+public interface ModelCacheable {
+
+    /**
+     * Should this be used in a model cache
+     */
+    boolean shouldCache();
+
+    /**
+     * Sets if this should use a model cache or not
+     */
+    void setUseModelCache(boolean value);
+
+    /**
+     * Returns the model instance for model caching
+     */
+    ModelInstance getModelInstance();
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
@@ -23,6 +23,7 @@ import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.math.collision.BoundingBox;
 import com.mbrlabs.mundus.commons.env.lights.DirectionalLight;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
+import com.mbrlabs.mundus.commons.scene3d.ModelCacheable;
 import com.mbrlabs.mundus.commons.shadows.ShadowMapper;
 import com.mbrlabs.mundus.commons.utils.LightUtils;
 
@@ -66,6 +67,13 @@ public abstract class CullableComponent extends AbstractComponent {
         if (!gameObject.sceneGraph.scene.settings.useFrustumCulling) {
             isCulled = false;
             return;
+        }
+
+        // Cannot frustum cull model cache objects, no reason for perform calculations
+        if (this instanceof ModelCacheable) {
+            if (((ModelCacheable) this).shouldCache()) {
+                isCulled = false;
+            }
         }
 
         boolean visibleToPerspective;

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
@@ -170,6 +170,8 @@ public class ModelComponent extends CullableComponent implements AssetUsage, Cli
         mc.shader = this.shader;
         mc.materials = this.materials;
         mc.setDimensions(mc.modelInstance);
+        mc.setUseModelCache(useModelCache);
+        gameObject.sceneGraph.scene.modelCacheManager.requestModelCacheRebuild();
         return mc;
     }
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
@@ -26,6 +26,7 @@ import com.mbrlabs.mundus.commons.assets.MaterialAsset;
 import com.mbrlabs.mundus.commons.assets.ModelAsset;
 import com.mbrlabs.mundus.commons.assets.TextureAsset;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
+import com.mbrlabs.mundus.commons.scene3d.ModelCacheable;
 import com.mbrlabs.mundus.commons.shaders.ClippableShader;
 import com.mbrlabs.mundus.commons.shaders.ShadowMapShader;
 
@@ -35,11 +36,12 @@ import java.util.Objects;
  * @author Marcus Brummer
  * @version 17-01-2016
  */
-public class ModelComponent extends CullableComponent implements AssetUsage, ClippableComponent {
+public class ModelComponent extends CullableComponent implements AssetUsage, ClippableComponent, ModelCacheable {
 
     protected ModelAsset modelAsset;
     protected ModelInstance modelInstance;
     protected Shader shader;
+    protected boolean useModelCache = false;
 
     protected ObjectMap<String, MaterialAsset> materials;  // g3db material id to material asset uuid
 
@@ -97,6 +99,17 @@ public class ModelComponent extends CullableComponent implements AssetUsage, Cli
         }
     }
 
+    @Override
+    public boolean shouldCache() {
+        return useModelCache;
+    }
+
+    @Override
+    public void setUseModelCache(boolean value) {
+        useModelCache = value;
+    }
+
+    @Override
     public ModelInstance getModelInstance() {
         return modelInstance;
     }
@@ -108,7 +121,7 @@ public class ModelComponent extends CullableComponent implements AssetUsage, Cli
 
         super.render(delta);
 
-        if (isCulled) return;
+        if (isCulled || useModelCache) return;
 
         if (shader != null) {
             gameObject.sceneGraph.scene.batch.render(modelInstance, gameObject.sceneGraph.scene.environment, shader);
@@ -119,7 +132,7 @@ public class ModelComponent extends CullableComponent implements AssetUsage, Cli
 
     @Override
     public void renderDepth(float delta, Vector3 clippingPlane, float clipHeight, Shader depthShader) {
-        if (isCulled) return;
+        if (isCulled || useModelCache) return;
 
         if (depthShader instanceof ClippableShader) {
             ((ClippableShader) depthShader).setClippingPlane(clippingPlane);

--- a/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
@@ -33,6 +33,7 @@ import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.core.registry.Registry
 import com.mbrlabs.mundus.editor.events.FilesDroppedEvent
 import com.mbrlabs.mundus.editor.events.FullScreenEvent
+import com.mbrlabs.mundus.editor.events.GameObjectModifiedEvent
 import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
 import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.input.FreeCamController
@@ -59,7 +60,8 @@ import org.lwjgl.opengl.GL11
 class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
         ProjectChangedEvent.ProjectChangedListener,
         SceneChangedEvent.SceneChangedListener,
-        FullScreenEvent.FullScreenEventListener {
+        FullScreenEvent.FullScreenEventListener,
+        GameObjectModifiedEvent.GameObjectModifiedListener {
 
     private lateinit var axesInstance: ModelInstance
     private lateinit var compass: Compass
@@ -249,6 +251,11 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
 
     override fun filesDropped(files: Array<out String>?) {
         Mundus.postEvent(FilesDroppedEvent(files))
+    }
+
+    override fun onGameObjectModified(event: GameObjectModifiedEvent) {
+        if (event.gameObject == null) return
+        projectManager.current().currScene.modelCacheManager.requestModelCacheRebuild()
     }
 
     override fun dispose() {

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/converter/ModelComponentConverter.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/converter/ModelComponentConverter.java
@@ -22,7 +22,6 @@ import com.mbrlabs.mundus.commons.assets.ModelAsset;
 import com.mbrlabs.mundus.commons.dto.ModelComponentDTO;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.editor.scene3d.components.PickableModelComponent;
-import com.mbrlabs.mundus.editor.shader.Shaders;
 import com.mbrlabs.mundus.editor.utils.Log;
 
 import java.util.Map;
@@ -48,6 +47,7 @@ public class ModelComponentConverter {
 
         PickableModelComponent component = new PickableModelComponent(go);
         component.setModel(model, false);
+        component.setUseModelCache(dto.isUseModelCache());
 
         for (String g3dbMatID : dto.getMaterials().keySet()) {
             String uuid = dto.getMaterials().get(g3dbMatID);
@@ -64,6 +64,7 @@ public class ModelComponentConverter {
     public static ModelComponentDTO convert(PickableModelComponent modelComponent) {
         ModelComponentDTO dto = new ModelComponentDTO();
         dto.setModelID(modelComponent.getModelAsset().getID());
+        dto.setUseModelCache(modelComponent.shouldCache());
 
         // materials
         for (String g3dbMatID : modelComponent.getMaterials().keys()) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/history/commands/DeleteCommand.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/history/commands/DeleteCommand.kt
@@ -17,6 +17,7 @@ package com.mbrlabs.mundus.editor.history.commands
 
 import com.badlogic.gdx.scenes.scene2d.ui.Tree
 import com.mbrlabs.mundus.commons.scene3d.GameObject
+import com.mbrlabs.mundus.commons.scene3d.ModelCacheManager
 import com.mbrlabs.mundus.commons.scene3d.components.Component
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.events.ComponentAddedEvent
@@ -54,6 +55,7 @@ class DeleteCommand(private var go: GameObject?, private var node: Outline.Outli
         // remove from outline tree
         tree!!.remove(node)
         Mundus.postEvent(SceneGraphChangedEvent())
+        ModelCacheManager.rebuildIfCached(go, true)
     }
 
     override fun undo() {
@@ -67,6 +69,7 @@ class DeleteCommand(private var go: GameObject?, private var node: Outline.Outli
             parentNode!!.add(node)
         node.expandTo()
         Mundus.postEvent(SceneGraphChangedEvent())
+        ModelCacheManager.rebuildIfCached(go, true)
 
         // For components that utilize gizmos we should send a ComponentAddedEvent
         // so that GizmoManager can update as needed.

--- a/editor/src/main/com/mbrlabs/mundus/editor/scene3d/components/PickableModelComponent.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/scene3d/components/PickableModelComponent.java
@@ -58,7 +58,9 @@ public class PickableModelComponent extends ModelComponent implements PickableCo
         mc.shader = this.shader;
         mc.materials = this.materials;
         mc.setDimensions(mc.modelInstance);
+        mc.setUseModelCache(useModelCache);
         mc.encodeRaypickColorId();
+        gameObject.sceneGraph.scene.modelCacheManager.requestModelCacheRebuild();
         return mc;
     }
 }

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/ModelComponentConverter.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/ModelComponentConverter.java
@@ -38,6 +38,7 @@ public class ModelComponentConverter {
                                          Shaders shaders, AssetManager assetManager) {
         ModelComponent mc = new ModelComponent(gameObject);
         mc.setModel((ModelAsset) assetManager.findAssetByID(modelComponentDTO.getModelID()), false);
+        mc.setUseModelCache(modelComponentDTO.isUseModelCache());
 
         for(Map.Entry<String, String> entry : modelComponentDTO.getMaterials().entrySet()) {
             mc.getMaterials().put(entry.getKey(), (MaterialAsset) assetManager.findAssetByID(entry.getValue()));


### PR DESCRIPTION
Adds some basic model caching capabilities. Introduces new ModelCacheManager class within a Scene for maintaining and building/rebuilding the cache. Static objects with Model Components can enable model caching by checking a new box .

![image](https://user-images.githubusercontent.com/28971753/182694687-79c593ed-898c-4b15-9815-371758e4b555.png)
