### PR TITLE
Add colorpicking to each material

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/scene3d/components/PickableModelComponent.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/scene3d/components/PickableModelComponent.java
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.editor.scene3d.components;
 
+import com.badlogic.gdx.graphics.g3d.Material;
 import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.graphics.g3d.Shader;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
@@ -42,7 +43,9 @@ public class PickableModelComponent extends ModelComponent implements PickableCo
     @Override
     public void encodeRaypickColorId() {
         PickerIDAttribute goIDa = PickerColorEncoder.encodeRaypickColorId(gameObject);
-        this.modelInstance.materials.first().set(goIDa);
+        for (Material material : modelInstance.materials) {
+            material.set(goIDa);
+        }
     }
 
     @Override


### PR DESCRIPTION
Resolves issue with color picking only working on the first material when model has multiple materials. 