### PR TITLE
Scene name validation

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
@@ -30,7 +30,6 @@ import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
 import com.mbrlabs.mundus.editor.events.SceneAddedEvent
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.utils.Log
-import org.apache.commons.lang3.StringUtils
 
 /**
  * @author Marcus Brummer
@@ -55,9 +54,10 @@ class SceneMenu : Menu("Scenes"),
         addScene.addListener(object : ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 Dialogs.showInputDialog(UI, "Add Scene", "Name:", SceneNameValidator(), object : InputDialogAdapter() {
-                    override fun finished(input: String?) {
+                    override fun finished(input: String) {
+                        val newSceneName = input.trim()
                         val project = projectManager.current()
-                        val scene = projectManager.createScene(project, input)
+                        val scene = projectManager.createScene(project, newSceneName)
                         projectManager.changeScene(project, scene.name)
                         Mundus.postEvent(SceneAddedEvent(scene))
                     }
@@ -107,7 +107,7 @@ class SceneMenu : Menu("Scenes"),
 
     inner class SceneNameValidator : InputValidator {
         override fun validateInput(input: String): Boolean {
-            return StringUtils.EMPTY != input;
+            return input.isNotBlank()
         }
 
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
@@ -19,6 +19,7 @@ package com.mbrlabs.mundus.editor.ui.modules.menu
 import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
 import com.badlogic.gdx.utils.Array
+import com.kotcrab.vis.ui.util.InputValidator
 import com.kotcrab.vis.ui.util.dialog.Dialogs
 import com.kotcrab.vis.ui.util.dialog.InputDialogAdapter
 import com.kotcrab.vis.ui.widget.Menu
@@ -29,6 +30,7 @@ import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
 import com.mbrlabs.mundus.editor.events.SceneAddedEvent
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.utils.Log
+import org.apache.commons.lang3.StringUtils
 
 /**
  * @author Marcus Brummer
@@ -52,7 +54,7 @@ class SceneMenu : Menu("Scenes"),
 
         addScene.addListener(object : ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
-                Dialogs.showInputDialog(UI, "Add Scene", "Name:", object : InputDialogAdapter() {
+                Dialogs.showInputDialog(UI, "Add Scene", "Name:", SceneNameValidator(), object : InputDialogAdapter() {
                     override fun finished(input: String?) {
                         val project = projectManager.current()
                         val scene = projectManager.createScene(project, input)
@@ -101,6 +103,13 @@ class SceneMenu : Menu("Scenes"),
         val sceneName = event.scene!!.name
         buildMenuItem(sceneName)
         Log.trace(TAG, "SceneMenu", "New scene [{}] added.", sceneName)
+    }
+
+    inner class SceneNameValidator : InputValidator {
+        override fun validateInput(input: String): Boolean {
+            return StringUtils.EMPTY != input;
+        }
+
     }
 
 }


### PR DESCRIPTION
Currently we can add scene with empty name and I think it is not a good behavior. 

With this fix we can not add new scene with empty or blank name:

![image](https://user-images.githubusercontent.com/1684274/196638313-c371f93d-83e8-42aa-97ea-9fdd80523706.png)
![image](https://user-images.githubusercontent.com/1684274/196638448-9de58ccf-25c0-49c1-9cff-d9ab053a8221.png)
