### PR TITLE
Scene deleting

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -2,6 +2,7 @@
 - Convert Water Shader to an Uber Shader
 - Water Shader Enhancements (visible depth, toggle reflection/refraction)
 - Skybox rendering performance tweak
+- Added scene delete button
 
 [0.4.0] ~ 10/12/2022
 - [BREAKING CHANGE] The ModelShader was replaced with custom PBR shader.

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -524,6 +524,17 @@ public class ProjectManager implements Disposable {
         }
     }
 
+    /**
+     * Deletes scene
+     *
+     * @param project The project context
+     * @param sceneName The screen name
+     */
+    public void deleteScene(final ProjectContext project, final String sceneName) {
+        project.scenes.removeValue(sceneName, false);
+        SceneManager.deleteScene(project, sceneName);
+    }
+
     private void initGameObject(ProjectContext context, GameObject root) {
         initComponents(context, root);
         if (root.getChildren() != null) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/scene/SceneManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/scene/SceneManager.java
@@ -62,6 +62,18 @@ public class SceneManager {
         return json.fromJson(SceneDTO.class, new FileInputStream(sceneDir));
     }
 
+    /**
+     * Deletes scene.
+     *
+     * @param context project context of the scene
+     * @param sceneName name of the scene to remove
+     */
+    public static void deleteScene(final ProjectContext context, final String sceneName) {
+        final String sceneDir = getScenePath(context, sceneName);
+        FileHandle sceneFile = Gdx.files.absolute(sceneDir);
+        sceneFile.delete();
+    }
+
     private static String getScenePath(ProjectContext context, String sceneName) {
         return FilenameUtils.concat(context.path + "/" + ProjectManager.PROJECT_SCENES_DIR,
                 sceneName + "." + ProjectManager.PROJECT_SCENE_EXTENSION);

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/FileMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/FileMenu.kt
@@ -55,7 +55,7 @@ class FileMenu : Menu("File") {
         saveProject.setShortcut(Input.Keys.CONTROL_LEFT, Input.Keys.S)
 
         // setup recent projects
-        val recentPrjectsPopup = PopupMenu()
+        val recentProjectsPopup = PopupMenu()
         for (ref in registry.projects) {
             val pro = MenuItem(ref.name + " - [" + ref.path + "]")
             pro.addListener(object : ClickListener() {
@@ -70,9 +70,9 @@ class FileMenu : Menu("File") {
 
                 }
             })
-            recentPrjectsPopup.addItem(pro)
+            recentProjectsPopup.addItem(pro)
         }
-        recentProjects.subMenu = recentPrjectsPopup
+        recentProjects.subMenu = recentProjectsPopup
 
         addItem(newProject)
         addItem(importProject)

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
@@ -17,6 +17,7 @@
 package com.mbrlabs.mundus.editor.ui.modules.menu
 
 import com.badlogic.gdx.scenes.scene2d.InputEvent
+import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
 import com.badlogic.gdx.utils.Array
 import com.kotcrab.vis.ui.util.dialog.Dialogs
@@ -41,6 +42,7 @@ class SceneMenu : Menu("Scenes"),
 
     companion object {
         private val TAG = SceneMenu::class.java.simpleName
+        private const val DELETE_BUTTON_NAME = "delete_scene_submenu"
     }
 
     private val sceneItems = Array<MenuItem>()
@@ -100,6 +102,17 @@ class SceneMenu : Menu("Scenes"),
         menuItem.addListener(object: ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 projectManager.changeScene(projectManager.current(), sceneName)
+
+                for (mi in sceneItems) {
+                    val deleteMenuItem = mi.subMenu.findActor<MenuItem>(DELETE_BUTTON_NAME)
+
+                    // Enable other delete buttons and disable current delete button
+                    if (mi.text.contentEquals(sceneName)) {
+                        disableMenuItem(deleteMenuItem)
+                    } else {
+                        enableMenuItem(deleteMenuItem)
+                    }
+                }
             }
         })
         return menuItem
@@ -107,14 +120,32 @@ class SceneMenu : Menu("Scenes"),
 
     private fun buildDeleteSubMenuItem(sceneName: String, screenMenu: MenuItem): MenuItem {
         val menuItem = MenuItem("Delete")
+        menuItem.name = DELETE_BUTTON_NAME
         menuItem.addListener(object: ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 projectManager.deleteScene(projectManager.current(), sceneName)
+                sceneItems.removeValue(screenMenu, true)
                 removeActor(screenMenu)
                 pack()
             }
         })
+
+        // The current scene's delete button will be disabled
+        if (projectManager.current().activeSceneName.equals(sceneName)) {
+            disableMenuItem(menuItem)
+        }
+
         return menuItem
+    }
+
+    private fun disableMenuItem(menuItem: MenuItem) {
+        menuItem.touchable = Touchable.disabled
+        menuItem.isDisabled = true
+    }
+
+    private fun enableMenuItem(menuItem: MenuItem) {
+        menuItem.touchable = Touchable.enabled
+        menuItem.isDisabled = false
     }
 
     override fun onProjectChanged(event: ProjectChangedEvent) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
@@ -82,11 +82,11 @@ class SceneMenu : Menu("Scenes"),
     }
 
     private fun buildMenuItem(sceneName: String): MenuItem {
+        val menuItem = MenuItem(sceneName)
+
         val subMenus = PopupMenu()
         subMenus.addItem(buildChangeToSubMenuItem(sceneName))
-        subMenus.addItem(buildDeleteSubMenuItem(sceneName))
-
-        val menuItem = MenuItem(sceneName)
+        subMenus.addItem(buildDeleteSubMenuItem(sceneName, menuItem))
         menuItem.subMenu = subMenus
 
         addItem(menuItem)
@@ -105,11 +105,13 @@ class SceneMenu : Menu("Scenes"),
         return menuItem
     }
 
-    private fun buildDeleteSubMenuItem(sceneName: String): MenuItem {
+    private fun buildDeleteSubMenuItem(sceneName: String, screenMenu: MenuItem): MenuItem {
         val menuItem = MenuItem("Delete")
         menuItem.addListener(object: ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
-                // TODO
+                projectManager.deleteScene(projectManager.current(), sceneName)
+                removeActor(screenMenu)
+                pack()
             }
         })
         return menuItem

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
@@ -23,6 +23,7 @@ import com.kotcrab.vis.ui.util.dialog.Dialogs
 import com.kotcrab.vis.ui.util.dialog.InputDialogAdapter
 import com.kotcrab.vis.ui.widget.Menu
 import com.kotcrab.vis.ui.widget.MenuItem
+import com.kotcrab.vis.ui.widget.PopupMenu
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
@@ -81,15 +82,36 @@ class SceneMenu : Menu("Scenes"),
     }
 
     private fun buildMenuItem(sceneName: String): MenuItem {
+        val subMenus = PopupMenu()
+        subMenus.addItem(buildChangeToSubMenuItem(sceneName))
+        subMenus.addItem(buildDeleteSubMenuItem(sceneName))
+
         val menuItem = MenuItem(sceneName)
-        menuItem.addListener(object : ClickListener() {
+        menuItem.subMenu = subMenus
+
+        addItem(menuItem)
+        sceneItems.add(menuItem)
+
+        return menuItem
+    }
+
+    private fun buildChangeToSubMenuItem(sceneName: String): MenuItem {
+        val menuItem = MenuItem("Change to")
+        menuItem.addListener(object: ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 projectManager.changeScene(projectManager.current(), sceneName)
             }
         })
-        addItem(menuItem)
-        sceneItems.add(menuItem)
+        return menuItem
+    }
 
+    private fun buildDeleteSubMenuItem(sceneName: String): MenuItem {
+        val menuItem = MenuItem("Delete")
+        menuItem.addListener(object: ClickListener() {
+            override fun clicked(event: InputEvent?, x: Float, y: Float) {
+                // TODO
+            }
+        })
         return menuItem
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
@@ -88,7 +88,7 @@ class SceneMenu : Menu("Scenes"),
         val menuItem = MenuItem(sceneName)
 
         val subMenus = PopupMenu()
-        subMenus.addItem(buildChangeToSubMenuItem(sceneName))
+        subMenus.addItem(buildOpenSubMenuItem(sceneName))
         subMenus.addItem(buildDeleteSubMenuItem(sceneName, menuItem))
         menuItem.subMenu = subMenus
 
@@ -98,8 +98,8 @@ class SceneMenu : Menu("Scenes"),
         return menuItem
     }
 
-    private fun buildChangeToSubMenuItem(sceneName: String): MenuItem {
-        val menuItem = MenuItem("Change to")
+    private fun buildOpenSubMenuItem(sceneName: String): MenuItem {
+        val menuItem = MenuItem("Open")
         menuItem.addListener(object: ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 projectManager.changeScene(projectManager.current(), sceneName)

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
@@ -114,12 +114,13 @@ class SceneMenu : Menu("Scenes"),
         menuItem.name = DELETE_BUTTON_NAME
         menuItem.addListener(object: ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
-                Dialogs.showOptionDialog(UI, "Deleting scene", "Are you sure you want to delete '" + sceneName + "' scene?", Dialogs.OptionDialogType.YES_CANCEL, object : OptionDialogAdapter() {
+                Dialogs.showOptionDialog(UI, "Deleting scene", "Are you sure you want to delete '$sceneName' scene?", Dialogs.OptionDialogType.YES_CANCEL, object : OptionDialogAdapter() {
                     override fun yes() {
                         projectManager.deleteScene(projectManager.current(), sceneName)
                         sceneItems.removeValue(screenMenu, true)
                         removeActor(screenMenu)
                         pack()
+                        Log.trace(TAG, "SceneMenu", "Scene [{}] deleted.", sceneName)
                     }
                 })
             }
@@ -163,9 +164,8 @@ class SceneMenu : Menu("Scenes"),
     override fun onSceneAdded(event: SceneAddedEvent) {
         val sceneName = event.scene!!.name
         buildMenuItem(sceneName)
-        Log.trace(TAG, "SceneMenu", "New scene [{}] added.", sceneName)
-
         updateDeleteButtonEnable(sceneName)
+        Log.trace(TAG, "SceneMenu", "New scene [{}] added.", sceneName)
     }
 
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
@@ -103,17 +103,7 @@ class SceneMenu : Menu("Scenes"),
         menuItem.addListener(object: ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 projectManager.changeScene(projectManager.current(), sceneName)
-
-                for (mi in sceneItems) {
-                    val deleteMenuItem = mi.subMenu.findActor<MenuItem>(DELETE_BUTTON_NAME)
-
-                    // Enable other delete buttons and disable current delete button
-                    if (mi.text.contentEquals(sceneName)) {
-                        disableMenuItem(deleteMenuItem)
-                    } else {
-                        enableMenuItem(deleteMenuItem)
-                    }
-                }
+                updateDeleteButtonEnable(sceneName)
             }
         })
         return menuItem
@@ -143,6 +133,19 @@ class SceneMenu : Menu("Scenes"),
         return menuItem
     }
 
+    private fun updateDeleteButtonEnable(currentSceneName: String) {
+        for (mi in sceneItems) {
+            val deleteMenuItem = mi.subMenu.findActor<MenuItem>(DELETE_BUTTON_NAME)
+
+            // Enable other delete buttons and disable current delete button
+            if (mi.text.contentEquals(currentSceneName)) {
+                disableMenuItem(deleteMenuItem)
+            } else {
+                enableMenuItem(deleteMenuItem)
+            }
+        }
+    }
+
     private fun disableMenuItem(menuItem: MenuItem) {
         menuItem.touchable = Touchable.disabled
         menuItem.isDisabled = true
@@ -161,6 +164,8 @@ class SceneMenu : Menu("Scenes"),
         val sceneName = event.scene!!.name
         buildMenuItem(sceneName)
         Log.trace(TAG, "SceneMenu", "New scene [{}] added.", sceneName)
+
+        updateDeleteButtonEnable(sceneName)
     }
 
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
@@ -22,6 +22,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
 import com.badlogic.gdx.utils.Array
 import com.kotcrab.vis.ui.util.dialog.Dialogs
 import com.kotcrab.vis.ui.util.dialog.InputDialogAdapter
+import com.kotcrab.vis.ui.util.dialog.OptionDialogAdapter
 import com.kotcrab.vis.ui.widget.Menu
 import com.kotcrab.vis.ui.widget.MenuItem
 import com.kotcrab.vis.ui.widget.PopupMenu
@@ -123,10 +124,14 @@ class SceneMenu : Menu("Scenes"),
         menuItem.name = DELETE_BUTTON_NAME
         menuItem.addListener(object: ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
-                projectManager.deleteScene(projectManager.current(), sceneName)
-                sceneItems.removeValue(screenMenu, true)
-                removeActor(screenMenu)
-                pack()
+                Dialogs.showOptionDialog(UI, "Deleting scene", "Are you sure you want to delete '" + sceneName + "' scene?", Dialogs.OptionDialogType.YES_CANCEL, object : OptionDialogAdapter() {
+                    override fun yes() {
+                        projectManager.deleteScene(projectManager.current(), sceneName)
+                        sceneItems.removeValue(screenMenu, true)
+                        removeActor(screenMenu)
+                        pack()
+                    }
+                })
             }
         })
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
@@ -120,10 +120,17 @@ class SceneMenu : Menu("Scenes"),
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 Dialogs.showOptionDialog(UI, "Deleting scene", "Are you sure you want to delete '$sceneName' scene?", Dialogs.OptionDialogType.YES_CANCEL, object : OptionDialogAdapter() {
                     override fun yes() {
+                        // Delete scene file
                         projectManager.deleteScene(projectManager.current(), sceneName)
+
+                        // Delete scene from project
+                        kryoManager.saveProjectContext(projectManager.current())
+
+                        // Delete scene from UI
                         sceneItems.removeValue(screenMenu, true)
                         removeActor(screenMenu)
                         pack()
+
                         Log.trace(TAG, "SceneMenu", "Scene [{}] deleted.", sceneName)
                     }
                 })
@@ -170,7 +177,7 @@ class SceneMenu : Menu("Scenes"),
         buildMenuItem(sceneName)
         updateDeleteButtonEnable(sceneName)
 
-        // Save context here so that the ID above is persisted in .pro file
+        // Save context here so that the scene name above is persisted in .pro file
         kryoManager.saveProjectContext(projectManager.current())
 
         Log.trace(TAG, "SceneMenu", "New scene [{}] added.", sceneName)


### PR DESCRIPTION
Added submenus to scene menu. 
* `Open` - Opens the selected scene
* `Delete` - Deletes the scene

![image](https://user-images.githubusercontent.com/1684274/196658969-b4aad0c3-0128-4016-b8f6-a54d997ede04.png)

The `Delete` button is disabled on the current selected scene:

![image](https://user-images.githubusercontent.com/1684274/196658912-61fa8113-dc74-44a6-8f4f-e4e512b277d9.png)



After clicked to the `Delete` button then the application shows a confirmation modal:

![image](https://user-images.githubusercontent.com/1684274/196656385-37ea7800-119a-4cf0-a402-f9b0cd411e74.png)
