### PR TITLE
Add external model object

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
@@ -18,11 +18,14 @@ package com.mbrlabs.mundus.commons.scene3d;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g3d.Model;
+import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.graphics.g3d.Shader;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 import com.mbrlabs.mundus.commons.Scene;
 import com.mbrlabs.mundus.commons.scene3d.components.Component;
+import com.mbrlabs.mundus.commons.scene3d.components.ModelComponent;
 import com.mbrlabs.mundus.commons.scene3d.components.WaterComponent;
 
 /**
@@ -98,6 +101,56 @@ public class SceneGraph {
         if (waterComponent != null) {
             containsWater = true;
         }
+    }
+
+    /**
+     * Adds a model to the scene graph to the given position.
+     *
+     * @param model The model.
+     * @param position The position.
+     * @return The game object of added model.
+     */
+    public GameObject addGameObject(final Model model, final Vector3 position) {
+        return addGameObject(new ModelInstance(model), position);
+    }
+
+    /**
+     * Adds a model instance to the scene graph to the given position.
+     *
+     * @param modelInstance The model instance.
+     * @param position The position.
+     * @return The game object of added model instance.
+     */
+    public GameObject addGameObject(final ModelInstance modelInstance, final Vector3 position) {
+        final GameObject go = new GameObject(this, "", getNextId());
+
+        go.translate(position);
+
+        ModelComponent modelComponent = new ModelComponent(go);
+        modelComponent.setModel(modelInstance);
+
+        try {
+            go.addComponent(modelComponent);
+        } catch (final InvalidComponentException ex) {
+            // Because we created a new game object which has not any component
+            // this exception won't throw
+        }
+
+        root.addChild(go);
+
+        return go;
+    }
+
+    private int getNextId() {
+        int maxId = 0;
+
+        for (final GameObject go : root.getChildren()) {
+            if (go.id > maxId) {
+                maxId = go.id;
+            }
+        }
+
+        return maxId + 1;
     }
 
     public GameObject getRoot() {

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
@@ -82,6 +82,13 @@ public class ModelComponent extends CullableComponent implements AssetUsage, Cli
         setDimensions(modelInstance);
     }
 
+    public void setModel(final ModelInstance modelInstance) {
+        this.modelInstance = modelInstance;
+        modelInstance.transform = gameObject.getTransform();
+
+        setDimensions(this.modelInstance);
+    }
+
     public ObjectMap<String, MaterialAsset> getMaterials() {
         return materials;
     }

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -1,3 +1,6 @@
+[0.5.0] ~
+- Added 'addGameObject(ModelInstance, Vector3)' and 'addGameObject(Model, Vector3)' methods to SceneGraph to add external model to scene graph
+
 [0.4.0] ~ 10/12/2022
 - [BREAKING CHANGE] The loadScene method for the runtime has changed. A ModelBatch is no longer required to be passed in.
 - Added config parameter to Mundus constructor


### PR DESCRIPTION
A added two methods:
- addGameObject(ModelInstance, Vector3)
- addGameObject(Model, Vector3)

into SceneGraph.

There methods can add external model object into the scene graph.


https://user-images.githubusercontent.com/1684274/197379088-ea7a6be4-5147-4074-987b-469eeeb474e4.mp4

Test code:

```
        private Mundus mundus;
	private Scene scene;
	private FirstPersonCameraController controller;
	
	@Override
	public void create () {
		mundus = new Mundus(Gdx.files.internal("mundus"));
		mundus.getAssetManager().getGdxAssetManager().load("uploads_files_2305968.gltf", SceneAsset.class);
		mundus.getAssetManager().getGdxAssetManager().finishLoading();
		SceneAsset sceneAsset = mundus.getAssetManager().getGdxAssetManager().get("uploads_files_2305968.gltf");
		mundus.getAssetManager().maxNumBones = 30;

		scene = mundus.loadScene("Main Scene.mundus");

		scene.cam.position.set(10, 10, 10);
		scene.cam.direction.rotate(Vector3.Y, 70);
		scene.cam.direction.rotate(Vector3.Z, -20);

		scene.sceneGraph.addGameObject( new ModelInstance(sceneAsset.scene.model), new Vector3(10, 2, 10));

		controller = new FirstPersonCameraController(scene.cam);
		controller.setVelocity(200f);
		Gdx.input.setInputProcessor(controller);
	}

	@Override
	public void render () {
		ScreenUtils.clear(1, 0, 0, 1);

		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);

		controller.update();
		scene.sceneGraph.update();
		scene.render();

		if (Gdx.input.isKeyJustPressed(Input.Keys.F)) {
			SceneAsset sceneAsset = mundus.getAssetManager().getGdxAssetManager().get("uploads_files_2305968.gltf");
			scene.sceneGraph.addGameObject(sceneAsset.scene.model, new Vector3(MathUtils.random(100), 2, MathUtils.random(100)));
		}
	}

```
If the map has not any model, we should set manually the `maxNumBones`.