### PR TITLE
Make terrain assets reusable

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/TerrainComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/TerrainComponent.java
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.commons.scene3d.components;
 
+import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.graphics.g3d.Shader;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
@@ -24,7 +25,6 @@ import com.mbrlabs.mundus.commons.assets.Asset;
 import com.mbrlabs.mundus.commons.assets.TerrainAsset;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.shaders.ClippableShader;
-import com.mbrlabs.mundus.commons.shaders.ShadowMapShader;
 import com.mbrlabs.mundus.commons.shaders.TerrainUberShader;
 
 import java.util.Objects;
@@ -37,7 +37,8 @@ public class TerrainComponent extends CullableComponent implements AssetUsage, C
 
     private static final String TAG = TerrainComponent.class.getSimpleName();
 
-    protected TerrainAsset terrain;
+    protected ModelInstance modelInstance;
+    protected TerrainAsset terrainAsset;
     protected Shader shader;
 
     public TerrainComponent(GameObject go, Shader shader) {
@@ -47,16 +48,18 @@ public class TerrainComponent extends CullableComponent implements AssetUsage, C
     }
 
     public void updateUVs(Vector2 uvScale) {
-        terrain.updateUvScale(uvScale);
+        terrainAsset.updateUvScale(uvScale);
     }
 
-    public void setTerrain(TerrainAsset terrain) {
-        this.terrain = terrain;
-        setDimensions(terrain.getTerrain().modelInstance);
+    public void setTerrainAsset(TerrainAsset terrainAsset) {
+        this.terrainAsset = terrainAsset;
+        modelInstance = new ModelInstance(terrainAsset.getTerrain().getModel());
+        modelInstance.transform = gameObject.getTransform();
+        setDimensions(modelInstance);
     }
 
-    public TerrainAsset getTerrain() {
-        return terrain;
+    public TerrainAsset getTerrainAsset() {
+        return terrainAsset;
     }
 
     public Shader getShader() {
@@ -71,7 +74,7 @@ public class TerrainComponent extends CullableComponent implements AssetUsage, C
     public void render(float delta) {
         super.render(delta);
         if (isCulled) return;
-        gameObject.sceneGraph.scene.batch.render(terrain.getTerrain(), gameObject.sceneGraph.scene.environment);
+        gameObject.sceneGraph.scene.batch.render(modelInstance, gameObject.sceneGraph.scene.environment);
     }
 
     @Override
@@ -90,7 +93,7 @@ public class TerrainComponent extends CullableComponent implements AssetUsage, C
             ((ClippableShader) shader).setClippingHeight(clipHeight);
         }
 
-        gameObject.sceneGraph.scene.depthBatch.render(terrain.getTerrain(), gameObject.sceneGraph.scene.environment, shader);
+        gameObject.sceneGraph.scene.depthBatch.render(modelInstance, gameObject.sceneGraph.scene.environment, shader);
     }
 
     @Override
@@ -100,9 +103,13 @@ public class TerrainComponent extends CullableComponent implements AssetUsage, C
 
     @Override
     public boolean usesAsset(Asset assetToCheck) {
-        if (Objects.equals(terrain.getID(), assetToCheck.getID()))
+        if (Objects.equals(terrainAsset.getID(), assetToCheck.getID()))
             return true;
 
-        return terrain.usesAsset(assetToCheck);
+        return terrainAsset.usesAsset(assetToCheck);
+    }
+
+    public ModelInstance getModelInstance() {
+        return modelInstance;
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/TerrainComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/TerrainComponent.java
@@ -112,4 +112,42 @@ public class TerrainComponent extends CullableComponent implements AssetUsage, C
     public ModelInstance getModelInstance() {
         return modelInstance;
     }
+
+    /**
+     * Returns the terrain height at the given world coordinates, in world coordinates.
+     *
+     * @param worldX X world position to get height
+     * @param worldZ Z world position to get height
+     * @return float height value
+     */
+    public float getHeightAtWorldCoord(float worldX, float worldZ) {
+        return terrainAsset.getTerrain().getHeightAtWorldCoord(worldX, worldZ, modelInstance.transform);
+    }
+
+    /**
+     * Get normal at world coordinates. The methods calculates exact point
+     * position in terrain coordinates and returns normal at that point. If
+     * point doesn't belong to terrain -- it returns default
+     * <code>Vector.Y<code> normal.
+     *
+     * @param worldX
+     *            the x coord in world
+     * @param worldZ
+     *            the z coord in world
+     * @return normal at that point. If point doesn't belong to terrain -- it
+     *         returns default <code>Vector.Y<code> normal.
+     */
+    public Vector3 getNormalAtWordCoordinate(Vector3 out, float worldX, float worldZ) {
+        return terrainAsset.getTerrain().getNormalAtWordCoordinate(out, worldX, worldZ, modelInstance.transform);
+    }
+
+    /**
+     * Determines if the world coordinates are within the terrains X and Z boundaries, does not including height
+     * @param worldX worldX to check
+     * @param worldZ worldZ to check
+     * @return boolean true if within the terrains boundary, else false
+     */
+    public boolean isOnTerrain(float worldX, float worldZ) {
+        return terrainAsset.getTerrain().isOnTerrain(worldX, worldZ, modelInstance.transform);
+    }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
@@ -41,7 +41,7 @@ import net.mgsx.gltf.loaders.shared.geometry.MeshTangentSpaceGenerator;
  */
 public class Terrain implements Disposable {
 
-    public static final int DEFAULT_SIZE = 1600;
+    public static final int DEFAULT_SIZE = 1200;
     public static final int DEFAULT_VERTEX_RESOLUTION = 180;
     public static final int DEFAULT_UV_SCALE = 60;
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
@@ -22,9 +22,6 @@ import com.badlogic.gdx.graphics.VertexAttribute;
 import com.badlogic.gdx.graphics.VertexAttributes;
 import com.badlogic.gdx.graphics.g3d.Material;
 import com.badlogic.gdx.graphics.g3d.Model;
-import com.badlogic.gdx.graphics.g3d.ModelInstance;
-import com.badlogic.gdx.graphics.g3d.Renderable;
-import com.badlogic.gdx.graphics.g3d.RenderableProvider;
 import com.badlogic.gdx.graphics.g3d.model.MeshPart;
 import com.badlogic.gdx.graphics.g3d.utils.MeshPartBuilder;
 import com.badlogic.gdx.graphics.g3d.utils.ModelBuilder;
@@ -33,9 +30,7 @@ import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.math.collision.Ray;
-import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
-import com.badlogic.gdx.utils.Pool;
 import com.mbrlabs.mundus.commons.terrain.attributes.TerrainTextureAttribute;
 import com.mbrlabs.mundus.commons.utils.MathUtils;
 import net.mgsx.gltf.loaders.shared.geometry.MeshTangentSpaceGenerator;
@@ -44,7 +39,7 @@ import net.mgsx.gltf.loaders.shared.geometry.MeshTangentSpaceGenerator;
  * @author Marcus Brummer
  * @version 30-11-2015
  */
-public class Terrain implements RenderableProvider, Disposable {
+public class Terrain implements Disposable {
 
     public static final int DEFAULT_SIZE = 1600;
     public static final int DEFAULT_VERTEX_RESOLUTION = 180;
@@ -58,7 +53,6 @@ public class Terrain implements RenderableProvider, Disposable {
     private static final Vector3 tmp = new Vector3();
     private static final Vector2 tmpV2 = new Vector2();
 
-    public Matrix4 transform;
     public float[] heightData;
     public int terrainWidth = 1200;
     public int terrainDepth = 1200;
@@ -79,11 +73,9 @@ public class Terrain implements RenderableProvider, Disposable {
 
     // Mesh
     private Model model;
-    public ModelInstance modelInstance;
     private Mesh mesh;
 
     private Terrain(int vertexResolution) {
-        this.transform = new Matrix4();
         this.attribs = new VertexAttributes(
                 VertexAttribute.Position(),
                 VertexAttribute.Normal(),
@@ -112,11 +104,6 @@ public class Terrain implements RenderableProvider, Disposable {
         this.heightData = heightData;
     }
 
-    public void setTransform(Matrix4 transform) {
-        this.transform = transform;
-        modelInstance.transform = this.transform;
-    }
-
     public void init() {
         final int numVertices = this.vertexResolution * vertexResolution;
         final int numIndices = (this.vertexResolution - 1) * (vertexResolution - 1) * 6;
@@ -133,8 +120,6 @@ public class Terrain implements RenderableProvider, Disposable {
         mb.begin();
         mb.part(meshPart, material);
         model = mb.end();
-        modelInstance = new ModelInstance(model);
-        modelInstance.transform = transform;
     }
 
     public Vector3 getVertexPosition(Vector3 out, int x, int z) {
@@ -145,8 +130,16 @@ public class Terrain implements RenderableProvider, Disposable {
         return out;
     }
 
-    public float getHeightAtWorldCoord(float worldX, float worldZ) {
-        transform.getTranslation(c00);
+    /**
+     * Returns the terrain height at the given world coordinates, in world coordinates.
+     *
+     * @param worldX X world position to get height
+     * @param worldZ Z world position to get height
+     * @param terrainTransform The world transform (modelInstance transform) of the terrain
+     * @return
+     */
+    public float getHeightAtWorldCoord(float worldX, float worldZ, Matrix4 terrainTransform) {
+        terrainTransform.getTranslation(c00);
         float terrainX = worldX - c00.x;
         float terrainZ = worldZ - c00.z;
 
@@ -174,19 +167,27 @@ public class Terrain implements RenderableProvider, Disposable {
         return MathUtils.barryCentric(c10, c11, c01, tmpV2.set(zCoord, xCoord));
     }
 
-    public Vector3 getRayIntersection(Vector3 out, Ray ray) {
+    /**
+     * Casts the given ray to determine where it intersects on the terrain.
+     *
+     * @param out Vector3 to populate with intersect point with
+     * @param ray the ray to cast
+     * @param terrainTransform The world transform (modelInstance transform) of the terrain
+     * @return
+     */
+    public Vector3 getRayIntersection(Vector3 out, Ray ray, Matrix4 terrainTransform) {
         // TODO improve performance. use binary search
         float curDistance = 2;
         int rounds = 0;
 
         ray.getEndPoint(out, curDistance);
-        boolean isUnder = isUnderTerrain(out);
+        boolean isUnder = isUnderTerrain(out, terrainTransform);
 
         while (true) {
             rounds++;
             ray.getEndPoint(out, curDistance);
 
-            boolean u = isUnderTerrain(out);
+            boolean u = isUnderTerrain(out, terrainTransform);
             if (u != isUnder || rounds == 20000) {
                 return out;
             }
@@ -197,10 +198,6 @@ public class Terrain implements RenderableProvider, Disposable {
 
     public Material getMaterial() {
         return material;
-    }
-
-    public ModelInstance getModelInstance() {
-        return modelInstance;
     }
 
     private short[] buildIndices() {
@@ -291,11 +288,13 @@ public class Terrain implements RenderableProvider, Disposable {
      *            the x coord in world
      * @param worldZ
      *            the z coord in world
+     * @param terrainTransform
+     *             The world transform (modelInstance transform) of the terrain
      * @return normal at that point. If point doesn't belong to terrain -- it
      *         returns default <code>Vector.Y<code> normal.
      */
-    public Vector3 getNormalAtWordCoordinate(Vector3 out, float worldX, float worldZ) {
-        transform.getTranslation(c00);
+    public Vector3 getNormalAtWordCoordinate(Vector3 out, float worldX, float worldZ, Matrix4 terrainTransform) {
+        terrainTransform.getTranslation(c00);
         float terrainX = worldX - c00.x;
         float terrainZ = worldZ - c00.z;
 
@@ -339,20 +338,28 @@ public class Terrain implements RenderableProvider, Disposable {
         return out;
     }
 
-    public boolean isUnderTerrain(Vector3 worldCoords) {
+    /**
+     * Checks if given world coordinates are above or below the terrain
+     * @param worldCoords the world coordinates to check
+     * @param terrainTransform the world transform (modelInstance transform) of the terrain
+     * @return boolean true if under the terrain, else false
+     */
+    public boolean isUnderTerrain(Vector3 worldCoords, Matrix4 terrainTransform) {
         // Factor in world height position as well via getPosition.
-        float terrainHeight = getHeightAtWorldCoord(worldCoords.x, worldCoords.z) + getPosition(tmp).y;
+        float terrainHeight = getHeightAtWorldCoord(worldCoords.x, worldCoords.z, terrainTransform) + terrainTransform.getTranslation(tmp).y;
         return terrainHeight > worldCoords.y;
     }
 
-    public boolean isOnTerrain(float worldX, float worldZ) {
-        transform.getTranslation(c00);
+    /**
+     * Determines if the world coordinates are within the terrains X and Z boundaries, does not including height
+     * @param worldX worldX to check
+     * @param worldZ worldZ to check
+     * @param terrainTransform the world transform (modelInstance transform) of the terrain
+     * @return boolean true if within the terrains boundary, else false
+     */
+    public boolean isOnTerrain(float worldX, float worldZ, Matrix4 terrainTransform) {
+        terrainTransform.getTranslation(c00);
         return worldX >= c00.x && worldX <= c00.x + terrainWidth && worldZ >= c00.z && worldZ <= c00.z + terrainDepth;
-    }
-
-    public Vector3 getPosition(Vector3 out) {
-        transform.getTranslation(out);
-        return out;
     }
 
     public TerrainTexture getTerrainTexture() {
@@ -387,9 +394,8 @@ public class Terrain implements RenderableProvider, Disposable {
         mesh.setVertices(vertices);
     }
 
-    @Override
-    public void getRenderables(Array<Renderable> renderables, Pool<Renderable> pool) {
-        modelInstance.getRenderables(renderables, pool);
+    public Model getModel() {
+        return model;
     }
 
     @Override

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -3,6 +3,7 @@
 - Water Shader Enhancements (visible depth, toggle reflection/refraction)
 - Skybox rendering performance tweak
 - Added scene delete button
+- Terrain Assets can now be reused in the same scene and other scenes
 
 [0.4.1]
 - Fix incorrect bone counts causing 1024 shader register error

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/EditorScene.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/EditorScene.java
@@ -20,8 +20,8 @@ import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.viewport.Viewport;
 import com.mbrlabs.mundus.commons.Scene;
-import com.mbrlabs.mundus.commons.assets.TerrainAsset;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
+import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent;
 import com.mbrlabs.mundus.commons.utils.NestableFrameBuffer;
 
 /**
@@ -31,7 +31,7 @@ import com.mbrlabs.mundus.commons.utils.NestableFrameBuffer;
 public class EditorScene extends Scene {
 
     public Viewport viewport;
-    public Array<TerrainAsset> terrains;
+    public Array<TerrainComponent> terrains;
     public GameObject currentSelection;
 
     public EditorScene() {

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/converter/TerrainComponentConverter.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/converter/TerrainComponentConverter.java
@@ -21,7 +21,6 @@ import com.mbrlabs.mundus.commons.assets.TerrainAsset;
 import com.mbrlabs.mundus.commons.dto.TerrainComponentDTO;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.editor.scene3d.components.PickableTerrainComponent;
-import com.mbrlabs.mundus.editor.shader.Shaders;
 import com.mbrlabs.mundus.editor.utils.Log;
 
 import java.util.Map;
@@ -46,9 +45,8 @@ public class TerrainComponentConverter {
             return null;
         }
 
-        terrain.getTerrain().transform = go.getTransform();
         PickableTerrainComponent terrainComponent = new PickableTerrainComponent(go, null);
-        terrainComponent.setTerrain(terrain);
+        terrainComponent.setTerrainAsset(terrain);
 
         return terrainComponent;
     }
@@ -58,7 +56,7 @@ public class TerrainComponentConverter {
      */
     public static TerrainComponentDTO convert(PickableTerrainComponent terrainComponent) {
         TerrainComponentDTO descriptor = new TerrainComponentDTO();
-        descriptor.setTerrainID(terrainComponent.getTerrain().getID());
+        descriptor.setTerrainID(terrainComponent.getTerrainAsset().getID());
 
         return descriptor;
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -475,7 +475,7 @@ public class ProjectManager implements Disposable {
         }
         for (Component c : terrainComponents) {
             if (c instanceof TerrainComponent) {
-                scene.terrains.add(((TerrainComponent) c).getTerrain());
+                scene.terrains.add(((TerrainComponent) c));
             }
         }
 
@@ -566,8 +566,6 @@ public class ProjectManager implements Disposable {
                 } else {
                     Log.fatal(TAG, "model for modelInstance not found: {}", modelComponent.getModelAsset().getID());
                 }
-            } else if (c.getType() == Component.Type.TERRAIN) {
-                ((TerrainComponent) c).getTerrain().getTerrain().setTransform(go.getTransform());
             } else if (c.getType() == Component.Type.WATER) {
                 ((WaterComponent) c).getWaterAsset().water.setTransform(go.getTransform());
             }

--- a/editor/src/main/com/mbrlabs/mundus/editor/scene3d/components/PickableTerrainComponent.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/scene3d/components/PickableTerrainComponent.java
@@ -36,12 +36,12 @@ public class PickableTerrainComponent extends TerrainComponent implements Pickab
     @Override
     public void encodeRaypickColorId() {
         PickerIDAttribute goIDa = PickerColorEncoder.encodeRaypickColorId(gameObject);
-        terrain.getTerrain().modelInstance.materials.first().set(goIDa);
+        modelInstance.materials.first().set(goIDa);
     }
 
     @Override
     public void renderPick() {
-        gameObject.sceneGraph.scene.batch.render(terrain.getTerrain(), Shaders.INSTANCE.getPickerShader());
+        gameObject.sceneGraph.scene.batch.render(modelInstance, Shaders.INSTANCE.getPickerShader());
     }
 
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/tools/SelectionTool.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/tools/SelectionTool.java
@@ -79,7 +79,7 @@ public class SelectionTool extends Tool {
                 // terrainAsset component
                 TerrainComponent tc = (TerrainComponent) go.findComponentByType(Component.Type.TERRAIN);
                 if (tc != null) {
-                    getProjectManager().getModelBatch().render(tc.getTerrain().getTerrain(), getShader());
+                    getProjectManager().getModelBatch().render(tc.getModelInstance(), getShader());
                 }
 
                 // terrainAsset component

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainDialog.kt
@@ -28,6 +28,7 @@ import com.mbrlabs.mundus.commons.assets.TerrainAsset
 import com.mbrlabs.mundus.commons.scene3d.components.Component
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
 import com.mbrlabs.mundus.commons.terrain.SplatMapResolution
+import com.mbrlabs.mundus.commons.terrain.Terrain
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.assets.AssetAlreadyExistsException
 import com.mbrlabs.mundus.editor.core.kryo.KryoManager
@@ -73,8 +74,8 @@ class AddTerrainDialog : BaseDialog("Add Terrain") {
     }
 
     private fun setDefaults() {
-        vertexResolution.text = "180"
-        terrainWidth.text = "1200"
+        vertexResolution.text = Terrain.DEFAULT_VERTEX_RESOLUTION.toString()
+        terrainWidth.text = Terrain.DEFAULT_SIZE.toString()
         positionX.text = "0"
         positionY.text = "0"
         positionZ.text = "0"

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainDialog.kt
@@ -25,6 +25,8 @@ import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
 import com.kotcrab.vis.ui.widget.VisTextField
 import com.mbrlabs.mundus.commons.assets.TerrainAsset
+import com.mbrlabs.mundus.commons.scene3d.components.Component
+import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
 import com.mbrlabs.mundus.commons.terrain.SplatMapResolution
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.assets.AssetAlreadyExistsException
@@ -32,7 +34,6 @@ import com.mbrlabs.mundus.editor.core.kryo.KryoManager
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.AssetImportEvent
 import com.mbrlabs.mundus.editor.events.SceneGraphChangedEvent
-import com.mbrlabs.mundus.editor.shader.Shaders
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.widgets.FloatFieldWithLabel
 import com.mbrlabs.mundus.editor.ui.widgets.IntegerFieldWithLabel
@@ -175,7 +176,8 @@ class AddTerrainDialog : BaseDialog("Add Terrain") {
                 sceneGraph.addGameObject(terrainGO)
                 terrainGO.setLocalPosition(posX, posY, posZ)
 
-                context.currScene.terrains.add(asset)
+                val terrainComponent = terrainGO.findComponentByType(Component.Type.TERRAIN)
+                context.currScene.terrains.add(terrainComponent as TerrainComponent?)
                 projectManager.current().assetManager.addNewAsset(asset)
                 Mundus.postEvent(AssetImportEvent(asset))
                 Mundus.postEvent(SceneGraphChangedEvent())

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/assets/TerrainAssetInspectorWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/assets/TerrainAssetInspectorWidget.kt
@@ -58,8 +58,11 @@ class TerrainAssetInspectorWidget : BaseInspectorWidget(TITLE) {
         collapsibleContent.add(splatMapSize).growX().row()
 
         // actions
-        collapsibleContent.add(VisLabel("Actions")).growX().row()
+        collapsibleContent.add(VisLabel("Actions")).padTop(5f).growX().row()
         collapsibleContent.addSeparator().padBottom(5f).row()
+        val placementLabel = VisLabel("Note: Places Terrain at 0,0,0. Modifying any placed instance of an existing Terrain Asset updates all instances.")
+        placementLabel.wrap = true
+        collapsibleContent.add(placementLabel).padBottom(5f).grow().row()
         collapsibleContent.add(terrainPlacement).growX().padBottom(15f).row()
 
         // model placement action

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/assets/TerrainAssetInspectorWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/assets/TerrainAssetInspectorWidget.kt
@@ -76,6 +76,8 @@ class TerrainAssetInspectorWidget : BaseInspectorWidget(TITLE) {
                 newComponent.terrainAsset = terrainAsset
                 newComponent.encodeRaypickColorId()
 
+                projectManager.current().currScene.terrains.add(newComponent)
+
                 modelGo.addComponent(newComponent)
 
                 postEvent(SceneGraphChangedEvent())

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainBrushGrid.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainBrushGrid.kt
@@ -67,7 +67,7 @@ class TerrainBrushGrid(private val parent: TerrainComponentWidget) : VisTable(),
         strengthSlider.value = TerrainBrush.getStrength()
         settingsTable.add(strengthSlider).expandX().fillX().row()
         strengthSlider.addListener(object : ChangeListener() {
-            override fun changed(event: ChangeListener.ChangeEvent, actor: Actor) {
+            override fun changed(event: ChangeEvent, actor: Actor) {
                 TerrainBrush.setStrength(strengthSlider.value)
             }
         })
@@ -84,7 +84,7 @@ class TerrainBrushGrid(private val parent: TerrainComponentWidget) : VisTable(),
         try {
             brush.mode = brushMode
             toolManager.activateTool(brush)
-            brush.terrainAsset = parent.component.terrain
+            brush.setTerrainComponent(parent.component)
         } catch (e: TerrainBrush.ModeNotSupportedException) {
             e.printStackTrace()
             Dialogs.showErrorDialog(UI, e.message)

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainGenTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainGenTab.kt
@@ -28,14 +28,14 @@ import com.mbrlabs.mundus.editor.ui.modules.inspector.components.terrain.generat
  * @author Marcus Brummer
  * @version 04-03-2016
  */
-class TerrainGenTab(private val parent: TerrainComponentWidget) : Tab(false, false), TabbedPaneListener {
+class TerrainGenTab(parent: TerrainComponentWidget) : Tab(false, false), TabbedPaneListener {
     private val root = VisTable()
 
     private val tabbedPane = TabbedPane()
     private val tabContainer = VisTable()
 
-    private val heightmapTab = HeightmapTab(parent.component.terrain)
-    private val perlinNoiseTab = PerlinNoiseTab(parent.component.terrain)
+    private val heightmapTab = HeightmapTab(parent.component.terrainAsset)
+    private val perlinNoiseTab = PerlinNoiseTab(parent.component.terrainAsset)
 
     init {
         tabbedPane.addListener(this)

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainPaintTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainPaintTab.kt
@@ -99,7 +99,7 @@ class TerrainPaintTab(private val parentWidget: TerrainComponentWidget) : Tab(fa
     private fun addTexture(textureAsset: TextureAsset) {
         val assetManager = projectManager.current().assetManager
 
-        val terrainAsset = this@TerrainPaintTab.parentWidget.component.terrain
+        val terrainAsset = this@TerrainPaintTab.parentWidget.component.terrainAsset
         val terrainTexture = terrainAsset.terrain.terrainTexture
 
         assetManager.addModifiedAsset(terrainAsset)
@@ -178,7 +178,7 @@ class TerrainPaintTab(private val parentWidget: TerrainComponentWidget) : Tab(fa
 
     private fun setTexturesInUiGrid() {
         textureGrid.removeTextures()
-        val terrainTexture = parentWidget.component.terrain.terrain.terrainTexture
+        val terrainTexture = parentWidget.component.terrainAsset.terrain.terrainTexture
         if (terrainTexture.getTexture(SplatTexture.Channel.BASE) != null) {
             textureGrid.addTexture(terrainTexture.getTexture(SplatTexture.Channel.BASE))
         }
@@ -224,7 +224,7 @@ class TerrainPaintTab(private val parentWidget: TerrainComponentWidget) : Tab(fa
             removeTexture.addListener(object : ClickListener() {
                 override fun clicked(event: InputEvent?, x: Float, y: Float) {
                     if (channel != null) {
-                        val terrain = parentWidget.component.terrain
+                        val terrain = parentWidget.component.terrainAsset
                         if (channel == SplatTexture.Channel.R) {
                             terrain.splatR = null
                             terrain.splatRNormal = null
@@ -256,7 +256,7 @@ class TerrainPaintTab(private val parentWidget: TerrainComponentWidget) : Tab(fa
                         UI.assetSelectionDialog.show(false, AssetTextureFilter(), object: AssetPickerDialog.AssetPickerListener {
                             override fun onSelected(asset: Asset?) {
                                 if (channel != null) {
-                                    val terrain = parentWidget.component.terrain
+                                    val terrain = parentWidget.component.terrainAsset
                                     if (channel == SplatTexture.Channel.BASE) {
                                         terrain.splatBase = asset as TextureAsset
                                     } else if (channel == SplatTexture.Channel.R) {
@@ -286,7 +286,7 @@ class TerrainPaintTab(private val parentWidget: TerrainComponentWidget) : Tab(fa
                         UI.assetSelectionDialog.show(false, AssetTextureFilter(), object: AssetPickerDialog.AssetPickerListener {
                             override fun onSelected(asset: Asset?) {
                                 if (channel != null) {
-                                    val terrain = parentWidget.component.terrain
+                                    val terrain = parentWidget.component.terrainAsset
                                     if (channel == SplatTexture.Channel.BASE) {
                                         terrain.splatBaseNormal = asset as TextureAsset
                                     } else if (channel == SplatTexture.Channel.R) {
@@ -312,7 +312,7 @@ class TerrainPaintTab(private val parentWidget: TerrainComponentWidget) : Tab(fa
             removeNormalMap.addListener(object : ClickListener() {
                 override fun clicked(event: InputEvent?, x: Float, y: Float) {
                     if (channel != null) {
-                        val terrain = parentWidget.component.terrain
+                        val terrain = parentWidget.component.terrainAsset
                         if (channel == SplatTexture.Channel.BASE) {
                             terrain.splatBaseNormal = null
                         }
@@ -346,7 +346,7 @@ class TerrainPaintTab(private val parentWidget: TerrainComponentWidget) : Tab(fa
         private fun updateMenuVisibility() {
             // Show/Hide remove normal map button conditionally
             var normalMapRemoveVisible = false
-            val terrain = parentWidget.component.terrain
+            val terrain = parentWidget.component.terrainAsset
             if (channel == SplatTexture.Channel.BASE && terrain.splatBaseNormal != null) {
                 normalMapRemoveVisible = true
             } else if (channel == SplatTexture.Channel.R && terrain.splatRNormal != null) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainSettingsTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainSettingsTab.kt
@@ -44,12 +44,12 @@ class TerrainSettingsTab(private val parentWidget: TerrainComponentWidget) : Tab
         table.add(VisLabel("Settings")).row()
 
         table.add(VisLabel("UV scale")).left().row()
-        uvSlider.value = parentWidget.component.terrain.terrain.uvScale.x
+        uvSlider.value = parentWidget.component.terrainAsset.terrain.uvScale.x
         table.add(uvSlider).expandX().fillX().row()
         uvSlider.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent, actor: Actor) {
                 val assetManager = projectManager.current().assetManager
-                assetManager.addModifiedAsset(parentWidget.component.terrain)
+                assetManager.addModifiedAsset(parentWidget.component.terrainAsset)
                 parentWidget.component.updateUVs(Vector2(uvSlider.value, uvSlider.value))
             }
         })

--- a/editor/src/main/com/mbrlabs/mundus/editor/utils/ObjExporter.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/utils/ObjExporter.java
@@ -21,7 +21,7 @@ public class ObjExporter {
     private static final Vector3 tmpVec = new Vector3();
 
     public static void exportToObj(String fileName, Terrain terrain) throws GdxRuntimeException {
-        Model model = terrain.modelInstance.model;
+        Model model = terrain.getModel();
         int vertexResolution = terrain.vertexResolution;
         final int w = vertexResolution - 1;
         final int h = vertexResolution - 1;

--- a/editor/src/main/com/mbrlabs/mundus/editor/utils/TerrainUtils.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/utils/TerrainUtils.kt
@@ -26,18 +26,18 @@ import com.badlogic.gdx.utils.Array
 import com.mbrlabs.mundus.commons.assets.TerrainAsset
 import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph
+import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
 import com.mbrlabs.mundus.editor.scene3d.components.PickableTerrainComponent
 
 private var tempVI = VertexInfo()
 
 fun createTerrainGO(sg: SceneGraph, shader: Shader?, goID: Int, goName: String,
-                    terrain: TerrainAsset): GameObject {
+                    terrainAsset: TerrainAsset): GameObject {
     val terrainGO = GameObject(sg, null, goID)
     terrainGO.name = goName
 
-    terrain.terrain.setTransform(terrainGO.transform)
     val terrainComponent = PickableTerrainComponent(terrainGO, null)
-    terrainComponent.terrain = terrain
+    terrainComponent.terrainAsset = terrainAsset
     terrainGO.components.add(terrainComponent)
     terrainComponent.shader = shader
     terrainComponent.encodeRaypickColorId()
@@ -45,23 +45,23 @@ fun createTerrainGO(sg: SceneGraph, shader: Shader?, goID: Int, goName: String,
     return terrainGO
 }
 
-fun getRayIntersection(terrains: Array<TerrainAsset>, ray: Ray, out: Vector3): Vector3? {
+fun getRayIntersection(terrains: Array<TerrainComponent>, ray: Ray, out: Vector3): Vector3? {
     for (terrain in terrains) {
-        val terr = terrain.terrain
-        terr.getRayIntersection(out, ray)
-        if (terr.isOnTerrain(out.x, out.z)) {
+        val terr = terrain.terrainAsset.terrain
+        terr.getRayIntersection(out, ray, terrain.modelInstance.transform)
+        if (terr.isOnTerrain(out.x, out.z, terrain.modelInstance.transform)) {
             return out
         }
     }
     return null
 }
 
-fun getRayIntersectionAndUp(terrains: Array<TerrainAsset>, ray: Ray): VertexInfo? {
+fun getRayIntersectionAndUp(terrains: Array<TerrainComponent>, ray: Ray): VertexInfo? {
     for (terrain in terrains) {
-        val terr = terrain.terrain
-        terr.getRayIntersection(tempVI.position, ray)
-        if (terr.isOnTerrain(tempVI.position.x, tempVI.position.z)) {
-            terr.getNormalAtWordCoordinate(tempVI.normal, tempVI.position.x, tempVI.position.z)
+        val terr = terrain.terrainAsset.terrain
+        terr.getRayIntersection(tempVI.position, ray, terrain.modelInstance.transform)
+        if (terr.isOnTerrain(tempVI.position.x, tempVI.position.z, terrain.modelInstance.transform)) {
+            terr.getNormalAtWordCoordinate(tempVI.normal, tempVI.position.x, tempVI.position.z, terrain.modelInstance.transform)
             return tempVI
         }
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/utils/TestUtils.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/utils/TestUtils.kt
@@ -20,7 +20,7 @@ import com.badlogic.gdx.graphics.g3d.Model
 import com.badlogic.gdx.graphics.g3d.ModelInstance
 import com.badlogic.gdx.math.Vector3
 import com.badlogic.gdx.utils.Array
-import com.mbrlabs.mundus.commons.terrain.Terrain
+import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
 import java.util.*
 
 /**
@@ -30,7 +30,7 @@ import java.util.*
  */
 object TestUtils {
 
-    fun createABunchOfModelsOnTheTerrain(count: Int, model: Model, terrain: Terrain): Array<ModelInstance> {
+    fun createABunchOfModelsOnTheTerrain(count: Int, model: Model, terrainComponent: TerrainComponent): Array<ModelInstance> {
         val boxInstances = Array<ModelInstance>()
         val rand = Random()
 
@@ -38,11 +38,11 @@ object TestUtils {
 
         for (i in 0..count - 1) {
             val mi = ModelInstance(model)
-            terrain.transform.getTranslation(tv3)
+            terrainComponent.modelInstance.transform.getTranslation(tv3)
             mi.transform.setTranslation(tv3)
-            val x = terrain.terrainWidth * rand.nextFloat()
-            val z = terrain.terrainDepth * rand.nextFloat()
-            val y = terrain.getHeightAtWorldCoord(x, z)
+            val x = terrainComponent.terrainAsset.terrain.terrainWidth * rand.nextFloat()
+            val z = terrainComponent.terrainAsset.terrain.terrainDepth * rand.nextFloat()
+            val y = terrainComponent.terrainAsset.terrain.getHeightAtWorldCoord(x, z, terrainComponent.modelInstance.transform)
             mi.transform.translate(x, y, z)
             boxInstances.add(mi)
         }

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -1,4 +1,5 @@
 [0.5.0] ~
+- [Breaking Change] Terrain API modified to closer reflect Models
 - Added 'addGameObject(ModelInstance, Vector3)' and 'addGameObject(Model, Vector3)' methods to SceneGraph to add external model to scene graph
 
 [0.4.0] ~ 10/12/2022

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/SceneLoader.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/SceneLoader.java
@@ -104,8 +104,6 @@ public class SceneLoader {
                 } else {
                     Gdx.app.error(TAG, "Could not find model for instance: " + modelComponent.getModelAsset().getID());
                 }
-            } else if (c.getType() == Component.Type.TERRAIN) {
-                ((TerrainComponent) c).getTerrain().getTerrain().setTransform(go.getTransform());
             } else if (c.getType() == Component.Type.WATER) {
                 ((WaterComponent) c).getWaterAsset().water.setTransform(go.getTransform());
             }

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/TerrainComponentConverter.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/TerrainComponentConverter.java
@@ -34,7 +34,7 @@ public class TerrainComponentConverter {
     public static TerrainComponent convert(TerrainComponentDTO terrainComponentDTO, GameObject gameObject,
                                            Shaders shaders, AssetManager assetManager) {
         TerrainComponent tc = new TerrainComponent(gameObject, null);
-        tc.setTerrain((TerrainAsset) assetManager.findAssetByID(terrainComponentDTO.getTerrainID()));
+        tc.setTerrainAsset((TerrainAsset) assetManager.findAssetByID(terrainComponentDTO.getTerrainID()));
 
         return tc;
     }


### PR DESCRIPTION
The goal of this PR is to make Terrain Assets place-able and re-usable. Before, once a terrain asset was removed from a scene, it became unusable and could not be placed ever again. This PR adds a button when inspecting a terrain asset to add it to the scene (like models). The PR also makes it possible to reuse the same terrain asset in the same scene (like models). This required a somewhat large refactor of the Terrain class. The terrain class behaved like a ModelInstance, which made it difficult to be reusable. 

Instead the terrain class has been modified to behave more like a Model, and now TerrainComponent holds the ModelInstance reference (similar to ModelComponent) and transform data. Transform was removed from the Terrain class. This allows the asset/terrain to be reusable. Note that this does not COPY a terrain asset. If you modify one instance of the terrain, it will affect all instances (just like models).

This has a bonus of fixing a bug with terrain transforms where their positions sometimes do not update. 

https://user-images.githubusercontent.com/28971753/197410712-164de1a4-8239-47d1-ae2c-684cf73287d8.mp4

