### PR TITLE
Upgrade gdx-gltf to 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
         mockitoVersion = '1.10.19'
         commonsIoVersion = '2.5'
         commonsLangVersion = '3.12.0'
-        gltfVersion = '2.0.0-rc.1'
+        gltfVersion = '2.1.0'
 
         ktxVersion = '1.10.0-b2'
     }

--- a/commons/src/main/com/mbrlabs/mundus/commons/utils/ShaderUtils.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/utils/ShaderUtils.java
@@ -115,6 +115,10 @@ public class ShaderUtils {
         config.numPointLights = LightUtils.MAX_POINT_LIGHTS;
         config.numSpotLights = LightUtils.MAX_SPOT_LIGHTS;
         config.numBones = numBones;
+        // Disabled on gdx-gltf 2.1.0 upgrade for now as to not change current visuals, to support gamma correction properly
+        // I believe we would need to also update the other shaders to use gamma correction as well.
+        // or apply in post-process
+        config.manualGammaCorrection = false;
         config.defaultCullFace = GL20.GL_BACK;
         config.vertexShader = Gdx.files.classpath("com/mbrlabs/mundus/commons/shaders/custom-gdx-pbr.vs.glsl").readString();
         config.fragmentShader = Gdx.files.classpath("com/mbrlabs/mundus/commons/shaders/custom-gdx-pbr.fs.glsl").readString();

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -4,6 +4,8 @@
 - Skybox rendering performance tweak
 - Added scene delete button
 - Terrain Assets can now be reused in the same scene and other scenes
+- Update gdx-gltf to 2.1.0
+- Fix import of models with spaces in dependencies name
 
 [0.4.2] ~ 10/24/2022
 - Fix shader compilation error for Terrain when using normal maps


### PR DESCRIPTION
Upgrades gdx-gltf version to latest stable version. Also fixes a bug where models that use textures with spaces in the file name would not load. 