### PR TITLE
Add an Open asset directory button

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/assets/AssetsDock.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/assets/AssetsDock.kt
@@ -44,6 +44,7 @@ import com.mbrlabs.mundus.editor.events.*
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.widgets.AutoFocusScrollPane
 import com.mbrlabs.mundus.editor.utils.ObjExporter
+import java.awt.Desktop
 import java.lang.RuntimeException
 
 
@@ -69,6 +70,7 @@ class AssetsDock : Tab(false, false),
 
     private val assetOpsMenu = PopupMenu()
     private val renameAsset = MenuItem("Rename Asset")
+    private val openDirectoryAsset = MenuItem("Open Directory")
     private val deleteAsset = MenuItem("Delete Asset")
     private val exportTerrainAsset = MenuItem("Export to OBJ")
 
@@ -122,6 +124,9 @@ class AssetsDock : Tab(false, false),
 
         // asset ops right click menu
         assetOpsMenu.addItem(renameAsset)
+        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)) {
+            assetOpsMenu.addItem(openDirectoryAsset)
+        }
         assetOpsMenu.addItem(deleteAsset)
 
         registerListeners()
@@ -133,6 +138,14 @@ class AssetsDock : Tab(false, false),
                 currentSelection?.asset?.let {
                     projectManager.current().assetManager.deleteAssetSafe(it, projectManager)
                     reloadAssets()
+                }
+            }
+        })
+
+        openDirectoryAsset.addListener(object : ClickListener() {
+            override fun clicked(event: InputEvent, x: Float, y: Float) {
+                currentSelection?.asset?.let {
+                    Desktop.getDesktop().open(it.file.file().parentFile)
                 }
             }
         })


### PR DESCRIPTION
Adds a button to open/view the directory the asset file is in. Tested on Windows, not able to test on linux at this time.