### PR TITLE
Ability to duplicate materials

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/MaterialAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/MaterialAsset.java
@@ -459,4 +459,29 @@ public class MaterialAsset extends Asset {
     private boolean fileMatch(Asset childAsset, Asset assetToCheck) {
         return childAsset != null && childAsset.getFile().path().equals(assetToCheck.getFile().path());
     }
+
+    public void duplicateMaterialAsset(MaterialAsset materialAsset) {
+        this.setRoughness(materialAsset.getRoughness());
+        this.setOpacity(materialAsset.getOpacity());
+        this.setMetallic(materialAsset.getMetallic());
+        this.setAlphaTest(materialAsset.getAlphaTest());
+        this.setNormalScale(materialAsset.getNormalScale());
+        this.setShadowBias(materialAsset.getShadowBias());
+        this.setCullFace(materialAsset.getCullFace());
+
+        this.diffuseTexCoord = materialAsset.diffuseTexCoord.deepCopy();
+        this.normalTexCoord = materialAsset.normalTexCoord.deepCopy();
+        this.emissiveTexCoord = materialAsset.emissiveTexCoord.deepCopy();
+        this.metallicRoughnessTexCoord = materialAsset.metallicRoughnessTexCoord.deepCopy();
+        this.occlusionTexCoord = materialAsset.occlusionTexCoord.deepCopy();
+
+        this.diffuseColor = materialAsset.getDiffuseColor();
+        this.emissiveColor = materialAsset.getEmissiveColor();
+
+        this.setDiffuseTexture(materialAsset.getDiffuseTexture());
+        this.setNormalMap(materialAsset.getNormalMap());
+        this.setMetallicRoughnessTexture(materialAsset.getMetallicRoughnessTexture());
+        this.setEmissiveTexture(materialAsset.getEmissiveTexture());
+        this.setOcclusionTexture(materialAsset.getOcclusionTexture());
+    }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/TexCoordInfo.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/TexCoordInfo.java
@@ -33,4 +33,15 @@ public class TexCoordInfo {
         PROP_SCALE_V = property + ".scaleV";
         PROP_ROTATION_UV = property + ".rotationUV";
     }
+
+    public TexCoordInfo deepCopy() {
+        TexCoordInfo copied = new TexCoordInfo(this.property);
+        copied.uvIndex = this.uvIndex;
+        copied.offsetU = this.offsetU;
+        copied.offsetV = this.offsetV;
+        copied.scaleU = this.scaleU;
+        copied.scaleV = this.scaleV;
+        copied.rotationUV = this.rotationUV;
+        return copied;
+    }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
@@ -175,7 +175,7 @@ public class ModelComponent extends CullableComponent implements AssetUsage, Cli
         mc.modelAsset = this.modelAsset;
         mc.modelInstance = new ModelInstance(modelAsset.getModel());
         mc.shader = this.shader;
-        mc.materials = this.materials;
+        mc.materials.putAll(this.materials);
         mc.setDimensions(mc.modelInstance);
         mc.setUseModelCache(useModelCache);
         gameObject.sceneGraph.scene.modelCacheManager.requestModelCacheRebuild();

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -8,6 +8,7 @@
 - Update gdx-gltf to 2.1.0
 - Fix import of models with spaces in dependencies name
 - Fix selection after model delete
+- Duplicate materials from inspector
 
 [0.4.2] ~ 10/24/2022
 - Fix shader compilation error for Terrain when using normal maps

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -54,6 +54,7 @@ import org.apache.commons.io.FilenameUtils
 import java.io.BufferedOutputStream
 import java.io.DataOutputStream
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
 import java.util.*
@@ -421,6 +422,10 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
      */
     @Throws(IOException::class, AssetAlreadyExistsException::class)
     fun createMaterialAsset(name: String): MaterialAsset {
+        if (name.contains(File.separator)) {
+            throw FileNotFoundException("Material names cannot contain file separator")
+        }
+
         // create empty material file
         val path = FilenameUtils.concat(rootFolder.path(), name) + MaterialAsset.EXTENSION
         val matFile = Gdx.files.absolute(path)

--- a/editor/src/main/com/mbrlabs/mundus/editor/events/MaterialDuplicatedEvent.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/events/MaterialDuplicatedEvent.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.editor.events
+
+/**
+ * @author jake-goldsmith
+ * @version January 14, 2023
+ */
+class MaterialDuplicatedEvent {
+    interface MaterialDuplicatedEventListener {
+        @Subscribe
+        fun onMaterialDuplicated(event: MaterialDuplicatedEvent)
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/scene3d/components/PickableModelComponent.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/scene3d/components/PickableModelComponent.java
@@ -59,7 +59,7 @@ public class PickableModelComponent extends ModelComponent implements PickableCo
         mc.modelAsset = this.modelAsset;
         mc.modelInstance = new ModelInstance(modelAsset.getModel());
         mc.shader = this.shader;
-        mc.materials = this.materials;
+        mc.materials.putAll(this.materials);
         mc.setDimensions(mc.modelInstance);
         mc.setUseModelCache(useModelCache);
         mc.encodeRaypickColorId();

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/assets/AssetsDock.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/assets/AssetsDock.kt
@@ -57,7 +57,8 @@ class AssetsDock : Tab(false, false),
         AssetImportEvent.AssetImportListener,
         AssetDeletedEvent.AssetDeletedListener,
         GameObjectSelectedEvent.GameObjectSelectedListener,
-        FullScreenEvent.FullScreenEventListener {
+        FullScreenEvent.FullScreenEventListener,
+        MaterialDuplicatedEvent.MaterialDuplicatedEventListener {
 
     private val root = VisTable()
     private val filesViewContextContainer = VisTable(false)
@@ -231,6 +232,10 @@ class AssetsDock : Tab(false, false),
     override fun onFullScreenEvent(event: FullScreenEvent) {
         if (!event.isFullScreen)
             reloadAssets()
+    }
+
+    override fun onMaterialDuplicated(event: MaterialDuplicatedEvent) {
+        reloadAssets()
     }
 
     /**


### PR DESCRIPTION
Resolves #86 

Adds a button in the MaterialWidget shown in the object inspector to duplicate the current material so its properties can be changed without affecting all objects using the same material. The user is prompted to enter a name for the new material.

Edge cases checked:
* Material name already exists
* Material names are filenames so check there are no illegal characters
* Prevents file separators being added as filenames.

Other changes:
* Fixed a bug where when duplicating objects the materials ObjectMap in the `PickableModelComponent` and `ModelComponent` was assigned by reference rather than deep-copied so changing the materials on a duplicate item changed all of its duplicates materials too.

Usage:

1. To set up the scenario I have duplicated the Ship. In the MaterialWidget click "duplicate" to duplicate the material.

![demo1](https://user-images.githubusercontent.com/26692552/212572435-736a3f74-d89d-4ecb-ac92-6c06f94df24b.png)

2 Enter the desired name:

![demo2](https://user-images.githubusercontent.com/26692552/212572441-c0f8bb8a-6e7f-463a-a41d-3c72205f425c.png)

3. The duplicate material is created with the same properties as the original material. Changes can be made to its properties which only affect the new material. The new material asset is shown in the assets widget.

![demo3](https://user-images.githubusercontent.com/26692552/212572450-a24932be-316d-4790-a78f-38fa5b02ec65.png)

Todo: 
* Add automated tests. I need to do more research into how we could write good tests using this UI framework so will have to take a look into that later.


