### PR TITLE
Handle deleting of temp model files

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -9,6 +9,7 @@
 - Fix import of models with spaces in dependencies name
 - Fix selection after model delete
 - Fix temporary files not deleted on model import
+- Fix reset import model dialog on close
 - Duplicate materials from inspector
 
 [0.4.2] ~ 10/24/2022

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -8,6 +8,7 @@
 - Update gdx-gltf to 2.1.0
 - Fix import of models with spaces in dependencies name
 - Fix selection after model delete
+- Fix temporary files not deleted on model import
 - Duplicate materials from inspector
 
 [0.4.2] ~ 10/24/2022

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/importer/ImportModelDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/importer/ImportModelDialog.kt
@@ -77,6 +77,7 @@ import net.mgsx.gltf.scene3d.shaders.PBRShaderConfig
 import net.mgsx.gltf.scene3d.shaders.PBRShaderProvider
 import net.mgsx.gltf.scene3d.utils.IBLBuilder
 import java.io.IOException
+import java.nio.file.Paths
 
 /**
  * @author Marcus Brummer
@@ -106,6 +107,12 @@ class ImportModelDialog : BaseDialog("Import Mesh"), Disposable {
 
     override fun dispose() {
         importMeshTable.dispose()
+    }
+
+    override fun close() {
+        importMeshTable.deleteTempModel()
+        importMeshTable.resetDialog()
+        super.close()
     }
 
     /**
@@ -353,6 +360,29 @@ class ImportModelDialog : BaseDialog("Import Mesh"), Disposable {
                 previewInstance = null
             }
             modelBatch?.dispose()
+            modelInput.clear()
+        }
+
+        fun deleteTempModel() {
+            if (importedModel == null) return
+
+            val parentDirectory = importedModel?.file?.parent()
+            val isDir = parentDirectory?.isDirectory
+            if (isDir == true) {
+                val path = Paths.get("mundus", "temp")
+                val tempModelDirPath = parentDirectory.file().absolutePath
+                // A defensive check, just to make sure the directory we are deleting is in the temp directory
+                if (tempModelDirPath.contains(path.toString())) {
+                    parentDirectory.deleteDirectory()
+                    Mundus.postEvent(LogEvent("Deleted temporary model directory at $tempModelDirPath"))
+                }
+            }
+
+            importedModel = null
+        }
+
+        fun resetDialog() {
+            previewInstance = null
             modelInput.clear()
         }
     }


### PR DESCRIPTION
When importing models, they are first moved into a temporary directory for fbx conversion, if needed. However, they are never deleted on import completion or if the import was cancelled. On my own machine the mundus temp directory had 1 gigabyte of temp data. 

I have not added code to retroactively delete existing temp files, but this code will delete the temporary model files on either window close or import completion going forward.

Also adds code to 'reset' the import dialog, otherwise the import dialog when reopened shows the previous imported model.

Have not been able to test on Linux yet as my WSL is not working for some reason.