### PR TITLE
Have Scene Camera use base Camera class

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
@@ -17,6 +17,7 @@
 package com.mbrlabs.mundus.commons;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Cubemap;
 import com.badlogic.gdx.graphics.GL20;
@@ -64,7 +65,7 @@ public class Scene implements Disposable {
     public Skybox skybox;
     public String skyboxAssetId;
 
-    public PerspectiveCamera cam;
+    public Camera cam;
     public ModelBatch batch;
     public ModelBatch depthBatch;
     public ModelCacheManager modelCacheManager;

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -8,6 +8,7 @@
 - Update gdx-gltf to 2.1.0
 - Fix import of models with spaces in dependencies name
 - Fix selection after model delete
+- Change scene camera to be base camera class
 - Duplicate materials from inspector
 
 [0.4.2] ~ 10/24/2022

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/converter/SceneConverter.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/converter/SceneConverter.java
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.editor.core.converter;
 
+import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.mbrlabs.mundus.commons.Scene;
 import com.mbrlabs.mundus.commons.assets.Asset;
 import com.mbrlabs.mundus.commons.dto.GameObjectDTO;
@@ -79,7 +80,9 @@ public class SceneConverter {
         dto.setCamDirZ(scene.cam.direction.z);
         dto.setCamNearPlane(scene.cam.near);
         dto.setCamFarPlane(scene.cam.far);
-        dto.setCamFieldOfView(scene.cam.fieldOfView);
+        if (scene.cam instanceof PerspectiveCamera) {
+            dto.setCamFieldOfView(((PerspectiveCamera) scene.cam).fieldOfView);
+        }
         return dto;
     }
 
@@ -131,7 +134,9 @@ public class SceneConverter {
         scene.cam.direction.set(dto.getCamDirX(), dto.getCamDirY(), dto.getCamDirZ());
         scene.cam.near = dto.getCamNearPlane() > 0 ? dto.getCamNearPlane() : CameraSettings.DEFAULT_NEAR_PLANE;
         scene.cam.far = dto.getCamFarPlane() > 0 ? dto.getCamFarPlane() : CameraSettings.DEFAULT_FAR_PLANE;
-        scene.cam.fieldOfView = dto.getCamFieldOfView() > 0 ? dto.getCamFieldOfView() : CameraSettings.DEFAULT_FOV;
+        if (scene.cam instanceof PerspectiveCamera) {
+            ((PerspectiveCamera) scene.cam).fieldOfView = dto.getCamFieldOfView() > 0 ? dto.getCamFieldOfView() : CameraSettings.DEFAULT_FOV;
+        }
         scene.cam.update();
 
         return scene;

--- a/editor/src/main/com/mbrlabs/mundus/editor/tools/picker/ToolHandlePicker.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/tools/picker/ToolHandlePicker.java
@@ -17,7 +17,7 @@
 package com.mbrlabs.mundus.editor.tools.picker;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.graphics.PerspectiveCamera;
+import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.g3d.ModelBatch;
 import com.mbrlabs.mundus.editor.core.EditorScene;
@@ -54,7 +54,7 @@ public class ToolHandlePicker extends BasePicker {
         return null;
     }
 
-    private void renderPickableScene(ToolHandle[] handles, ModelBatch batch, PerspectiveCamera cam) {
+    private void renderPickableScene(ToolHandle[] handles, ModelBatch batch, Camera cam) {
         batch.begin(cam);
         for (ToolHandle handle : handles) {
             handle.renderPick(batch);

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/CameraSettingsTable.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/CameraSettingsTable.kt
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.editor.ui.modules.dialogs.settings
 
+import com.badlogic.gdx.graphics.PerspectiveCamera
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
@@ -81,7 +82,9 @@ class CameraSettingsTable : BaseSettingsTable(), ProjectChangedEvent.ProjectChan
     private fun updateValues() {
         nearPlane.text = projectManager.current().currScene.cam.near.toString()
         farPlane.text = projectManager.current().currScene.cam.far.toString()
-        fov.text = projectManager.current().currScene.cam.fieldOfView.toString()
+        if (projectManager.current().currScene.cam is PerspectiveCamera) {
+            fov.text = (projectManager.current().currScene.cam as PerspectiveCamera).fieldOfView.toString()
+        }
     }
 
     override fun onProjectChanged(event: ProjectChangedEvent) {
@@ -126,7 +129,9 @@ class CameraSettingsTable : BaseSettingsTable(), ProjectChangedEvent.ProjectChan
             override fun changed(event: ChangeEvent, actor: Actor) {
                 if(fov.isInputValid && !fov.isEmpty) {
                     try {
-                        projectManager.current().currScene.cam.fieldOfView = fov.text.toFloat()
+                        if (projectManager.current().currScene.cam is PerspectiveCamera) {
+                            (projectManager.current().currScene.cam as PerspectiveCamera).fieldOfView = fov.text.toFloat()
+                        }
                     }
                     catch (ex : NumberFormatException) {
                         Mundus.postEvent(LogEvent(LogType.ERROR,"Error parsing field " + fov.name))
@@ -139,7 +144,9 @@ class CameraSettingsTable : BaseSettingsTable(), ProjectChangedEvent.ProjectChan
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 projectManager.current().currScene.cam.near = CameraSettings.DEFAULT_NEAR_PLANE
                 projectManager.current().currScene.cam.far = CameraSettings.DEFAULT_FAR_PLANE
-                projectManager.current().currScene.cam.fieldOfView = CameraSettings.DEFAULT_FOV
+                if (projectManager.current().currScene.cam is PerspectiveCamera) {
+                    (projectManager.current().currScene.cam as PerspectiveCamera).fieldOfView = CameraSettings.DEFAULT_FOV
+                }
                 updateValues()
             }
         })

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/RenderWidget.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/RenderWidget.java
@@ -17,7 +17,6 @@
 package com.mbrlabs.mundus.editor.ui.widgets;
 
 import com.badlogic.gdx.graphics.Camera;
-import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.ui.Widget;
@@ -37,7 +36,7 @@ public class RenderWidget extends Widget {
     private Camera cam;
     private Renderer renderer;
 
-    public RenderWidget(PerspectiveCamera cam) {
+    public RenderWidget(Camera cam) {
         super();
         this.cam = cam;
         viewport = new ScreenViewport(this.cam);

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/RenderWidget.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/RenderWidget.java
@@ -34,7 +34,7 @@ public class RenderWidget extends Widget {
     private static Vector2 vec = new Vector2();
 
     private ScreenViewport viewport;
-    private PerspectiveCamera cam;
+    private Camera cam;
     private Renderer renderer;
 
     public RenderWidget(PerspectiveCamera cam) {
@@ -52,7 +52,7 @@ public class RenderWidget extends Widget {
         return viewport;
     }
 
-    public void setCam(PerspectiveCamera cam) {
+    public void setCam(Camera cam) {
         this.cam = cam;
         viewport.setCamera(cam);
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/utils/Compass.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/utils/Compass.kt
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.editor.utils
 
+import com.badlogic.gdx.graphics.Camera
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.GL20
 import com.badlogic.gdx.graphics.PerspectiveCamera
@@ -34,7 +35,7 @@ import com.badlogic.gdx.utils.Disposable
  * @author Marcus Brummer
  * @version 05-12-2015
  */
-class Compass(private var worldCam: PerspectiveCamera?) : Disposable {
+class Compass(private var worldCam: Camera?) : Disposable {
 
     private val ARROW_LENGTH = 0.05f
     private val ARROW_THIKNESS = 0.4f
@@ -67,7 +68,7 @@ class Compass(private var worldCam: PerspectiveCamera?) : Disposable {
         compassInstance.transform.translate(0.93f, 0.94f, 0f)
     }
 
-    fun setWorldCam(cam: PerspectiveCamera) {
+    fun setWorldCam(cam: Camera) {
         this.worldCam = cam
     }
 

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -1,6 +1,7 @@
 [0.5.0] ~
 - [Breaking Change] Terrain API modified to closer reflect Models
 - Added 'addGameObject(ModelInstance, Vector3)' and 'addGameObject(Model, Vector3)' methods to SceneGraph to add external model to scene graph
+- Change scene camera to be base camera class
 
 [0.4.0] ~ 10/12/2022
 - [BREAKING CHANGE] The loadScene method for the runtime has changed. A ModelBatch is no longer required to be passed in.

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/SceneConverter.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/SceneConverter.java
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.runtime.converter;
 
+import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.mbrlabs.mundus.commons.Scene;
 import com.mbrlabs.mundus.commons.assets.AssetManager;
 import com.mbrlabs.mundus.commons.dto.GameObjectDTO;
@@ -80,7 +81,9 @@ public class SceneConverter {
         // Set cam settings
         scene.cam.near = dto.getCamNearPlane() > 0 ? dto.getCamNearPlane() : CameraSettings.DEFAULT_NEAR_PLANE;
         scene.cam.far = dto.getCamFarPlane() > 0 ? dto.getCamFarPlane() : CameraSettings.DEFAULT_FAR_PLANE;
-        scene.cam.fieldOfView = dto.getCamFieldOfView() > 0 ? dto.getCamFieldOfView() : CameraSettings.DEFAULT_FOV;
+        if (scene.cam instanceof PerspectiveCamera) {
+            ((PerspectiveCamera) scene.cam).fieldOfView = dto.getCamFieldOfView() > 0 ? dto.getCamFieldOfView() : CameraSettings.DEFAULT_FOV;
+        }
         scene.cam.update();
 
         return scene;


### PR DESCRIPTION
Updates the Scene.java camera to be a Camera instead of PerspectiveCamera. This allows runtime applications to change the camera to an Orthographic (or any other subclass of camera) if they wanted. No actual support added for Orthographic viewing within the editor it's self.