### PR TITLE
Fix menu icon size

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/MundusMenuBar.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/MundusMenuBar.kt
@@ -54,7 +54,7 @@ class MundusMenuBar : MenuBar() {
         val menuTable = super.getTable()
 
         val icon = VisImage(Texture(Gdx.files.internal("ui/menu_icon.png")))
-        root.add(icon).center().left().pad(5f)
+        root.add(icon).center().left().pad(5f).height(icon.height)
         root.add(menuTable).expand().fill().left().center().row()
         val sep = VisTable()
         sep.background = VisUI.getSkin().getDrawable("mundus-separator-green")


### PR DESCRIPTION
If I select a model then the menubar size changes. The inspector tries to use the max height if the scrollbar is visible and the menubar will smaller. I set fix size for icon, so inspector doesn't change the size. 

I've tested on Linux.

Before:
[before.webm](https://user-images.githubusercontent.com/1684274/221294258-9effde9f-5f02-4095-9522-5e5ebee71a66.webm)

After fix:
[after.webm](https://user-images.githubusercontent.com/1684274/221294350-32b5d26b-2d40-40f5-8b88-3de1e116f622.webm)
