### PR TITLE
Set default tool if select other game object

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
@@ -450,6 +450,8 @@ class Outline : VisTable(),
         tree.selection.clear()
         tree.selection.add(node)
         node.expandTo()
+
+        toolManager.setDefaultTool()
     }
 
     /**


### PR DESCRIPTION
I've found a selection bug in the outline. If I select terrain and select a brush tool and select another game object in the outline then the outline doesn't reset selection tool.

Before fix:
![before](https://user-images.githubusercontent.com/1684274/227198761-0f278fc5-113b-42ce-b2ba-21035118a1c3.gif)

After fix:
![after](https://user-images.githubusercontent.com/1684274/227198806-60b93906-5166-4354-9c5e-c26b7dbb527e.gif)

