### PR TITLE
Game object selection fix

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
@@ -451,7 +451,9 @@ class Outline : VisTable(),
         tree.selection.add(node)
         node.expandTo()
 
-        toolManager.setDefaultTool()
+        if (toolManager.activeTool !== toolManager.translateTool) {
+            toolManager.setDefaultTool()
+        }
     }
 
     /**


### PR DESCRIPTION
After this fix: https://github.com/JamesTKhan/Mundus/pull/142 the wireframe doesn't visible in certain cases. So here is a fix for it.