### PR TITLE
Fix word positions on rotated or scaled terrain

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
@@ -52,6 +52,7 @@ public class Terrain implements Disposable {
     private static final Vector3 c11 = new Vector3();
     private static final Vector3 tmp = new Vector3();
     private static final Vector2 tmpV2 = new Vector2();
+    private static final Matrix4 tmpMatrix = new Matrix4();
 
     public float[] heightData;
     public int terrainWidth = 1200;
@@ -141,9 +142,11 @@ public class Terrain implements Disposable {
      * @return
      */
     public float getHeightAtWorldCoord(float worldX, float worldZ, Matrix4 terrainTransform) {
-        terrainTransform.getTranslation(c00);
-        float terrainX = worldX - c00.x;
-        float terrainZ = worldZ - c00.z;
+        // Translates word coordinates to local coordinates
+        tmp.set(worldX, 0f, worldZ).mul(tmpMatrix.set(terrainTransform).inv());
+
+        float terrainX = tmp.x;
+        float terrainZ = tmp.z;
 
         float gridSquareSize = terrainWidth / ((float) vertexResolution - 1);
         int gridX = (int) Math.floor(terrainX / gridSquareSize);
@@ -296,9 +299,11 @@ public class Terrain implements Disposable {
      *         returns default <code>Vector.Y<code> normal.
      */
     public Vector3 getNormalAtWordCoordinate(Vector3 out, float worldX, float worldZ, Matrix4 terrainTransform) {
-        terrainTransform.getTranslation(c00);
-        float terrainX = worldX - c00.x;
-        float terrainZ = worldZ - c00.z;
+        // Translates word coordinates to local coordinates
+        tmp.set(worldX, 0f, worldZ).mul(tmpMatrix.set(terrainTransform).inv());
+
+        float terrainX = worldX - tmp.x;
+        float terrainZ = worldZ - tmp.z;
 
         float gridSquareSize = terrainWidth / ((float) vertexResolution - 1);
         int gridX = (int) Math.floor(terrainX / gridSquareSize);
@@ -360,8 +365,9 @@ public class Terrain implements Disposable {
      * @return boolean true if within the terrains boundary, else false
      */
     public boolean isOnTerrain(float worldX, float worldZ, Matrix4 terrainTransform) {
-        terrainTransform.getTranslation(c00);
-        return worldX >= c00.x && worldX <= c00.x + terrainWidth && worldZ >= c00.z && worldZ <= c00.z + terrainDepth;
+        // Translates word coordinates to local coordinates
+        tmp.set(worldX, 0f, worldZ).mul(tmpMatrix.set(terrainTransform).inv());
+        return 0 <= tmp.x && tmp.x <= terrainWidth && 0 <= tmp.z && tmp.z <= terrainDepth;
     }
 
     public TerrainMaterial getTerrainTexture() {

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -5,6 +5,7 @@
 - Change scene camera to be base camera class
 - Add active boolean to Skybox class to toggle rendering
 - Added new convenience methods to SceneGraph and GameObject for searching for GameObjects
+- Fix isOnTerrain, getNormalAtWordCoordinate and getHeightAtWorldCoord methods for rotated and scaled terrain
 
 [0.4.0] ~ 10/12/2022
 - [BREAKING CHANGE] The loadScene method for the runtime has changed. A ModelBatch is no longer required to be passed in.


### PR DESCRIPTION
Currently the `isOnTerrain`, `isUnderTerrain` and `getHeightAtWorldCoord` methods on `Terrain` are only check translation and don't check rotation and scaling. 

You can test them with these temporary codes in `FreeCamController` in editor:

isOnTerrain:

```kotlin
override fun mouseMoved(screenX: Int, screenY: Int): Boolean {
    if (camera == null) {
        return false
    }

    val currentProject = projectManager.current()
    val currentScene = currentProject.currScene
    val ray = currentScene.viewport.getPickRay(screenX.toFloat(), screenY.toFloat())

    for (terrain in currentScene.terrains) {
        val wordPos = getWorldPos(ray)
        val result = terrain.isOnTerrain(wordPos.x, wordPos.z)
       // You will see true value if the mouse is on terrain otherwise false
        println("wordPos: $wordPos, result: $result")
    }

    return true
}

private fun getWorldPos(ray: Ray): Vector3 {
    tmp.set(ray.origin)

    var round = 0
    var distance = 1f;

    while (tmp.y >= 1 && round < 5000) {
        ray.getEndPoint(tmp, distance)
        ++round
        ++distance
    }

    return tmp
}
```

_isUnderTerrain_:

```kotlin
override fun mouseMoved(screenX: Int, screenY: Int): Boolean {
    if (camera == null) {
        return false
    }

    val currentProject = projectManager.current()
    val currentScene = currentProject.currScene
    val ray = currentScene.viewport.getPickRay(screenX.toFloat(), screenY.toFloat())

    // getRayIntersection method uses inUnderTerrain method, se we can use it for test. 
    val result = getRayIntersection(currentScene.terrains, ray, Vector3())
    // You will see non null value if the mouse is on terrain, otherwise you will see null value
    println("$result")

    return true
}
```

_getHeightAtWorldCoord_:

```kotlin
override fun mouseMoved(screenX: Int, screenY: Int): Boolean {
    if (camera == null) {
        return false
    }

    val currentProject = projectManager.current()
    val currentScene = currentProject.currScene
    val ray = currentScene.viewport.getPickRay(screenX.toFloat(), screenY.toFloat())

    for (terrain in currentScene.terrains) {
        val wordPos = getWorldPos(ray)
        val result = terrain.getHeightAtWorldCoord(wordPos.x, wordPos.z)
        // You will see non 0 value if the mouse  is  on a hill, otherwise you will se 0 value
        println("wordPos: $wordPos, result: $result")
    }

    return true
}

private fun getWorldPos(ray: Ray): Vector3 {
    tmp.set(ray.origin)

    var round = 0
    var distance = 1f;

    while (tmp.y >= 1 && round < 5000) {
        ray.getEndPoint(tmp, distance)
        ++round
        ++distance
    }

    return tmp
}
```

Just you need add `currentProject` constructor parameter and add this parameter in `Mundus.kt`.