### PR TITLE
Set depth and samples for Editor

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/Main.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Main.kt
@@ -55,6 +55,7 @@ private fun launchEditor() {
     config.setWindowSizeLimits(1350, 1, 9999, 9999)
     config.setWindowPosition(-1, -1)
     config.setWindowIcon("icon/logo.png")
+    config.setBackBufferConfig(8, 8, 8, 8, 24, 0, 4);
 
     Lwjgl3Application(editor, config)
     Log.info(TAG, "Shutting down [{}]", TITLE)


### PR DESCRIPTION
The water rendering is a bit ugly if I see it from big distance, so I set Editor's depth to 24 and samples to 4.

Before fix:
![image](https://user-images.githubusercontent.com/1684274/233972113-82016391-398a-47bc-a775-2e90720a3324.png)

After fix:
![image](https://user-images.githubusercontent.com/1684274/233972003-7b5a54c9-da37-4e3c-abfe-b0132fdd04d5.png)
