### PR TITLE
Enable MSAA by default, with CLI to disable

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -6,6 +6,7 @@
 - Added scene rename button
 - Added dialog for adding water
 - Update gradle to 7.5.1
+- Updated editor to use MSAA by default, disable by command line
 - Terrain Assets can now be reused in the same scene and other scenes
 - Update gdx-gltf to 2.1.0
 - Fix import of models with spaces in dependencies name

--- a/editor/src/main/com/mbrlabs/mundus/editor/Main.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Main.kt
@@ -29,16 +29,17 @@ const private val TAG = "Main"
 const val VERSION = "v0.4.2"
 const val TITLE = "Mundus $VERSION"
 
-@Suppress("UNUSED_PARAMETER")
 fun main(arg: Array<String>) {
     // Temporary fix for MacOS, we should be able to remove when we update libGDX to 1.11.0 and use
     //  gdx-lwjgl3-glfw-awt-macos extension instead https://libgdx.com/news/2022/05/gdx-1-11
     StartOnFirstThreadHelper.startNewJvmIfRequired()
     Log.init()
-    launchEditor()
+
+    val noMSAA = arg.contains("noMSAA")
+    launchEditor(noMSAA)
 }
 
-private fun launchEditor() {
+private fun launchEditor(noMSAA: Boolean = false) {
     val config = Lwjgl3ApplicationConfiguration()
     val editor = Editor()
     config.setWindowListener(editor)
@@ -55,6 +56,9 @@ private fun launchEditor() {
     config.setWindowSizeLimits(1350, 1, 9999, 9999)
     config.setWindowPosition(-1, -1)
     config.setWindowIcon("icon/logo.png")
+
+    val aaSamples = if (noMSAA) 0 else 8
+    config.setBackBufferConfig(8, 8, 8, 8, 24, 0, aaSamples)
 
     Lwjgl3Application(editor, config)
     Log.info(TAG, "Shutting down [{}]", TITLE)


### PR DESCRIPTION
This PR sets the Editor to use 8 samples of MSAA by default. It can be disabled by program arguments for users with lower end hardware. This also sets the depth buffer to be 24 whereas the default was 16 (libGDX default) before. 