### PR TITLE
Fix Frustum culling with rotations

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
@@ -142,7 +142,6 @@ public abstract class CullableComponent extends AbstractComponent implements Mod
         tmpBounds.getCenter(center);
         tmpBounds.getDimensions(dimensions);
         gameObject.getScale(tmpScale);
-        center.scl(tmpScale);
         dimensions.scl(tmpScale);
         radius = dimensions.len() / 2f;
     }

--- a/commons/src/main/com/mbrlabs/mundus/commons/utils/ModelUtils.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/utils/ModelUtils.java
@@ -91,8 +91,7 @@ public class ModelUtils {
      * Checks if visible to camera using sphereInFrustum and radius
      */
     public static boolean isVisible(final Camera cam, final ModelInstance modelInstance, Vector3 center, float radius) {
-        modelInstance.transform.getTranslation(tmpVec0);
-        tmpVec0.add(center);
+        tmpVec0.set(center).mul(modelInstance.transform);
         return cam.frustum.sphereInFrustum(tmpVec0, radius);
     }
 

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -6,6 +6,7 @@
 - Add active boolean to Skybox class to toggle rendering
 - Added new convenience methods to SceneGraph and GameObject for searching for GameObjects
 - Fix isOnTerrain, getNormalAtWordCoordinate and getHeightAtWorldCoord methods for rotated and scaled terrain
+- Fix frustum culling not handling rotations
 
 [0.4.0] ~ 10/12/2022
 - [BREAKING CHANGE] The loadScene method for the runtime has changed. A ModelBatch is no longer required to be passed in.


### PR DESCRIPTION
Frustum check only added models center to the instance world position. This did not take into account rotations or scale properly. Updated frustum check to account for rotations. This issue is most noticeable with things like Terrain / water. 

@Dgzt can you test this when when you have a moment?