### PR TITLE
Reduce cull check matrix calcs

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
@@ -55,7 +55,7 @@ public abstract class CullableComponent extends AbstractComponent implements Mod
     protected float radius;
 
     // Render calls since last cull check
-    protected short lastCullCheck = 0;
+    protected short framesSinceLastCullCheck = 0;
 
     // Is it offscreen?
     protected boolean isCulled = false;
@@ -88,8 +88,8 @@ public abstract class CullableComponent extends AbstractComponent implements Mod
 
         // If object is not culled, don't perform a cull check every frame, just in intervals
         // to reduce matrix calculations
-        if (!isCulled && lastCullCheck++ < frameCullCheckInterval) return;
-        lastCullCheck = 0;
+        if (!isCulled && framesSinceLastCullCheck++ < frameCullCheckInterval) return;
+        framesSinceLastCullCheck = 0;
 
         boolean visibleToPerspective;
         boolean visibleToShadowMap = false;

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
@@ -47,7 +47,7 @@ import static com.mbrlabs.mundus.commons.utils.ModelUtils.isVisible;
 public abstract class CullableComponent extends AbstractComponent implements ModelEventable {
     private final static BoundingBox tmpBounds = new BoundingBox();
     private final static Vector3 tmpScale = new Vector3();
-    private final static short frameCullCheckInterval = 30;
+    private final static short frameCullCheckInterval = 15;
     private static DirectionalLight directionalLight;
 
     protected final Vector3 center = new Vector3();

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
@@ -47,11 +47,15 @@ import static com.mbrlabs.mundus.commons.utils.ModelUtils.isVisible;
 public abstract class CullableComponent extends AbstractComponent implements ModelEventable {
     private final static BoundingBox tmpBounds = new BoundingBox();
     private final static Vector3 tmpScale = new Vector3();
+    private final static short frameCullCheckInterval = 30;
     private static DirectionalLight directionalLight;
 
     protected final Vector3 center = new Vector3();
     protected final Vector3 dimensions = new Vector3();
     protected float radius;
+
+    // Render calls since last cull check
+    protected short lastCullCheck = 0;
 
     // Is it offscreen?
     protected boolean isCulled = false;
@@ -78,8 +82,14 @@ public abstract class CullableComponent extends AbstractComponent implements Mod
         if (this instanceof ModelCacheable) {
             if (((ModelCacheable) this).shouldCache()) {
                 isCulled = false;
+                return;
             }
         }
+
+        // If object is not culled, don't perform a cull check every frame, just in intervals
+        // to reduce matrix calculations
+        if (!isCulled && lastCullCheck++ < frameCullCheckInterval) return;
+        lastCullCheck = 0;
 
         boolean visibleToPerspective;
         boolean visibleToShadowMap = false;


### PR DESCRIPTION
Minor optimization to frustum cull checks. Frustum cull checks use 1 to 2  matrix multiplications every time. With this change, items that are not culled will only be checked every 15 frames instead of every frame. Also, added a return statement to modelCache culling logic that seems to be missing.