### PR TITLE
Show new game object name in Outline

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -19,6 +19,7 @@
 - Object picker can use with left mouse button. Switchable in the settings
 - Water creation dialog
 - Helper lines
+- Show renamed game object's new name after rename in Inspector
 
 [0.4.2] ~ 10/24/2022
 - Fix shader compilation error for Terrain when using normal maps

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/IdentifierWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/IdentifierWidget.kt
@@ -66,8 +66,9 @@ class IdentifierWidget : VisTable() {
         name.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent, actor: Actor) {
                 val projectContext = projectManager.current()
-                if (projectContext.currScene.currentSelection == null) return
-                projectContext.currScene.currentSelection.name = name.text
+                val selectedGO = projectContext.currScene.currentSelection ?: return
+                selectedGO.name = name.text
+                Mundus.postEvent(SceneGraphChangedEvent())
             }
         })
 


### PR DESCRIPTION
This change fixes if rename a game object in inspector (Identifier widget) the new name won't be in the Outline. 