### PR TITLE
Tool and game object selection bugfixes

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
@@ -38,8 +38,6 @@ public class SceneGraph {
 
     public Scene scene;
 
-    private GameObject selected;
-
     private boolean containsWater = false;
 
     public SceneGraph(Scene scene) {
@@ -198,14 +196,6 @@ public class SceneGraph {
 
     public GameObject getRoot() {
         return root;
-    }
-
-    public GameObject getSelected() {
-        return selected;
-    }
-
-    public void setSelected(GameObject selected) {
-        this.selected = selected;
     }
 
     public boolean isContainsWater() {

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -20,6 +20,7 @@
 - Water creation dialog
 - Helper lines
 - Show renamed game object's new name after rename in Inspector
+- Refactor tool selection
 
 [0.4.2] ~ 10/24/2022
 - Fix shader compilation error for Terrain when using normal maps

--- a/editor/src/main/com/mbrlabs/mundus/editor/events/ToolActivatedEvent.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/events/ToolActivatedEvent.kt
@@ -1,0 +1,9 @@
+package com.mbrlabs.mundus.editor.events
+
+class ToolActivatedEvent {
+
+    interface ToolActivatedEventListener {
+        @Subscribe
+        fun onToolActivatedEvent(event: ToolActivatedEvent)
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/tools/SelectionTool.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/tools/SelectionTool.java
@@ -86,7 +86,7 @@ public class SelectionTool extends Tool {
                     getProjectManager().getModelBatch().render(tc.getModelInstance(), getShader());
                 }
 
-                // terrainAsset component
+                // waterAsset component
                 WaterComponent wc = (WaterComponent) go.findComponentByType(Component.Type.WATER);
                 if (wc != null) {
                     getProjectManager().getModelBatch().render(wc.getWaterAsset().water, getShader());

--- a/editor/src/main/com/mbrlabs/mundus/editor/tools/ToolManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/tools/ToolManager.kt
@@ -127,6 +127,7 @@ class ToolManager(private val inputManager: InputManager,
                 Mundus.postEvent(ToolDeactivatedEvent())
             }
             setDefaultTool()
+            UI.docker.assetsDock.clearSelection()
             return true
         }
         return false

--- a/editor/src/main/com/mbrlabs/mundus/editor/tools/ToolManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/tools/ToolManager.kt
@@ -22,8 +22,9 @@ import com.badlogic.gdx.utils.Array
 import com.badlogic.gdx.utils.Disposable
 import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.editor.Mundus
-import com.mbrlabs.mundus.editor.core.project.ProjectContext
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
+import com.mbrlabs.mundus.editor.events.GameObjectSelectedEvent
+import com.mbrlabs.mundus.editor.events.ToolActivatedEvent
 import com.mbrlabs.mundus.editor.events.ToolDeactivatedEvent
 import com.mbrlabs.mundus.editor.history.CommandHistory
 import com.mbrlabs.mundus.editor.input.InputManager
@@ -31,6 +32,7 @@ import com.mbrlabs.mundus.editor.preferences.MundusPreferencesManager
 import com.mbrlabs.mundus.editor.tools.brushes.*
 import com.mbrlabs.mundus.editor.tools.picker.GameObjectPicker
 import com.mbrlabs.mundus.editor.tools.picker.ToolHandlePicker
+import com.mbrlabs.mundus.editor.ui.UI
 
 /**
  * @author Marcus Brummer
@@ -76,6 +78,7 @@ class ToolManager(private val inputManager: InputManager,
         if (shouldKeepSelection && selected != null) {
             (activeTool as SelectionTool?)!!.gameObjectSelected(selected)
         }
+        Mundus.postEvent(ToolActivatedEvent())
     }
 
     fun deactivateTool() {
@@ -87,7 +90,18 @@ class ToolManager(private val inputManager: InputManager,
     }
 
     fun setDefaultTool() {
-        if (activeTool == null || activeTool === modelPlacementTool || activeTool is TerrainBrush) activateTool(translateTool) else activeTool!!.onDisabled()
+        if (activeTool == null || activeTool === modelPlacementTool || activeTool is TerrainBrush) {
+            val selectedGO = UI.outline.getSelectedGameObject()
+            activateTool(translateTool)
+            if (selectedGO != null) {
+                activateTool(translateTool)
+                Mundus.postEvent(GameObjectSelectedEvent(UI.outline.getSelectedGameObject()))
+            }
+        } else {
+            activeTool!!.onDisabled()
+            UI.outline.clearSelection()
+            UI.inspector.clearWidgets()
+        }
     }
 
     fun render() {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/UI.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/UI.kt
@@ -78,7 +78,7 @@ object UI : Stage(ScreenViewport()) {
     var menuBar: MundusMenuBar
     var toolbar: MundusToolbar
     lateinit var statusBar: StatusBar
-    private val inspector: Inspector
+    val inspector: Inspector
     val outline: Outline
     private lateinit var docker: DockBar
     var sceneWidget: RenderWidget
@@ -128,8 +128,8 @@ object UI : Stage(ScreenViewport()) {
 
         mainContainer = VisTable()
         menuBar = MundusMenuBar()
-        toolbar = MundusToolbar()
         outline = Outline()
+        toolbar = MundusToolbar(outline)
         inspector = Inspector()
         sceneWidget = RenderWidget()
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/UI.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/UI.kt
@@ -80,7 +80,7 @@ object UI : Stage(ScreenViewport()) {
     lateinit var statusBar: StatusBar
     val inspector: Inspector
     val outline: Outline
-    private lateinit var docker: DockBar
+    lateinit var docker: DockBar
     var sceneWidget: RenderWidget
 
     // dialogs

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/MundusToolbar.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/MundusToolbar.kt
@@ -195,7 +195,6 @@ class MundusToolbar(private val outline: Outline) : Toolbar(),
                     toolManager.activateTool(toolManager.selectionTool)
                     val selectedGameObject = outline.getSelectedGameObject()
                     projectManager.current().currScene.currentSelection = selectedGameObject
-                    projectManager.current().currScene.sceneGraph.selected = selectedGameObject
             }
         })
 
@@ -205,7 +204,6 @@ class MundusToolbar(private val outline: Outline) : Toolbar(),
                     toolManager.activateTool(toolManager.translateTool)
                     val selectedGameObject = outline.getSelectedGameObject()
                     projectManager.current().currScene.currentSelection = selectedGameObject
-                    projectManager.current().currScene.sceneGraph.selected = selectedGameObject
             }
         })
 
@@ -215,7 +213,6 @@ class MundusToolbar(private val outline: Outline) : Toolbar(),
                     toolManager.activateTool(toolManager.rotateTool)
                     val selectedGameObject = outline.getSelectedGameObject()
                     projectManager.current().currScene.currentSelection = selectedGameObject
-                    projectManager.current().currScene.sceneGraph.selected = selectedGameObject
             }
         })
 
@@ -225,7 +222,6 @@ class MundusToolbar(private val outline: Outline) : Toolbar(),
                     toolManager.activateTool(toolManager.scaleTool)
                     val selectedGameObject = outline.getSelectedGameObject()
                     projectManager.current().currScene.currentSelection = selectedGameObject
-                    projectManager.current().currScene.sceneGraph.selected = selectedGameObject
             }
         })
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/MundusToolbar.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/MundusToolbar.kt
@@ -206,7 +206,6 @@ class MundusToolbar(private val outline: Outline) : Toolbar(),
                     val selectedGameObject = outline.getSelectedGameObject()
                     projectManager.current().currScene.currentSelection = selectedGameObject
                     projectManager.current().currScene.sceneGraph.selected = selectedGameObject
-//                }
             }
         })
 
@@ -217,7 +216,6 @@ class MundusToolbar(private val outline: Outline) : Toolbar(),
                     val selectedGameObject = outline.getSelectedGameObject()
                     projectManager.current().currScene.currentSelection = selectedGameObject
                     projectManager.current().currScene.sceneGraph.selected = selectedGameObject
-//                }
             }
         })
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/MundusToolbar.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/MundusToolbar.kt
@@ -25,10 +25,7 @@ import com.kotcrab.vis.ui.widget.PopupMenu
 import com.kotcrab.vis.ui.widget.Tooltip
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
-import com.mbrlabs.mundus.editor.events.AssetImportEvent
-import com.mbrlabs.mundus.editor.events.FullScreenEvent
-import com.mbrlabs.mundus.editor.events.GameObjectSelectedEvent
-import com.mbrlabs.mundus.editor.events.ToolActivatedEvent
+import com.mbrlabs.mundus.editor.events.*
 import com.mbrlabs.mundus.editor.tools.*
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.gizmos.GizmoManager
@@ -44,7 +41,12 @@ import com.mbrlabs.mundus.editor.utils.Log
  * *
  * @version 24-11-2015
  */
-class MundusToolbar(private val outline: Outline) : Toolbar(), FullScreenEvent.FullScreenEventListener, ToolActivatedEvent.ToolActivatedEventListener, GameObjectSelectedEvent.GameObjectSelectedListener {
+class MundusToolbar(private val outline: Outline) : Toolbar(),
+        FullScreenEvent.FullScreenEventListener,
+        ToolActivatedEvent.ToolActivatedEventListener,
+        GameObjectSelectedEvent.GameObjectSelectedListener,
+        AssetSelectedEvent.AssetSelectedListener
+{
 
     companion object {
         private val TAG = MundusToolbar::class.java.simpleName
@@ -285,6 +287,10 @@ class MundusToolbar(private val outline: Outline) : Toolbar(), FullScreenEvent.F
         }
         toolManager.translateTool.gameObjectSelected(event.gameObject)
         Mundus.postEvent(ToolActivatedEvent())
+    }
+
+    override fun onAssetSelected(event: AssetSelectedEvent) {
+        toolManager.setDefaultTool()
     }
 
     private fun clearButtonsStyle() {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddComponentDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddComponentDialog.kt
@@ -60,7 +60,7 @@ class AddComponentDialog : BaseDialog("Add Component") {
         addBtn.addListener(object : ClickListener () {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 // Add component to current game object
-                val go = projectManager.current().currScene.currentSelection
+                val go = UI.outline.getSelectedGameObject()!!
 
                 val component = getNewComponent(selectBox.selected, go)
                 if (component != null) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/DockBar.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/DockBar.kt
@@ -31,7 +31,7 @@ import com.mbrlabs.mundus.editor.ui.widgets.MundusSplitPane
  */
 class DockBar(private val splitPane: MundusSplitPane) : VisTable(), TabbedPaneListener {
 
-    private val assetsDock = AssetsDock()
+    val assetsDock = AssetsDock()
     private val logBar = LogBar()
     private val profilingBar = ProfilingBar()
     private val tabbedPane: TabbedPane

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/assets/AssetsDock.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/assets/AssetsDock.kt
@@ -133,6 +133,10 @@ class AssetsDock : Tab(false, false),
         registerListeners()
     }
 
+    fun clearSelection() {
+        setSelected(null)
+    }
+
     private fun registerListeners() {
         deleteAsset.addListener(object : ClickListener() {
             override fun clicked(event: InputEvent, x: Float, y: Float) {
@@ -226,7 +230,7 @@ class AssetsDock : Tab(false, false),
     }
 
     override fun onGameObjectSelected(event: GameObjectSelectedEvent) {
-        setSelected(null)
+        clearSelection()
     }
 
     override fun onFullScreenEvent(event: FullScreenEvent) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/Inspector.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/Inspector.kt
@@ -16,13 +16,11 @@
 
 package com.mbrlabs.mundus.editor.ui.modules.inspector
 
-import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.utils.Align
 import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisTable
 import com.mbrlabs.mundus.editor.Mundus
-import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.AssetSelectedEvent
 import com.mbrlabs.mundus.editor.events.ComponentAddedEvent
 import com.mbrlabs.mundus.editor.events.GameObjectModifiedEvent
@@ -47,8 +45,6 @@ class Inspector : VisTable(),
     enum class InspectorMode {
         GAME_OBJECT, ASSET, EMPTY
     }
-
-    private val projectManager: ProjectManager = Mundus.inject()
 
     private var mode = InspectorMode.EMPTY
     private val root = VisTable()
@@ -76,16 +72,6 @@ class Inspector : VisTable(),
         scrollPane.setFadeScrollBars(false)
 
         add<ScrollPane>(scrollPane).expand().fill().top()
-    }
-
-    override fun act(delta: Float) {
-        super.act(delta)
-
-        // If this widget is visible and the currentSelection variable is null (for example a brush tool selected) then
-        // disable this widget
-        val projectContext = projectManager.current()
-        val touchable = if (projectContext.currScene.currentSelection != null) Touchable.enabled else Touchable.disabled
-        this.touchable = touchable
     }
 
     fun clearWidgets() {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/Inspector.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/Inspector.kt
@@ -74,6 +74,11 @@ class Inspector : VisTable(),
         add<ScrollPane>(scrollPane).expand().fill().top()
     }
 
+    fun clearWidgets() {
+        root.clear()
+        mode = InspectorMode.EMPTY
+    }
+
     override fun onGameObjectSelected(event: GameObjectSelectedEvent) {
         if (mode != InspectorMode.GAME_OBJECT) {
             mode = InspectorMode.GAME_OBJECT

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/Inspector.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/Inspector.kt
@@ -16,11 +16,13 @@
 
 package com.mbrlabs.mundus.editor.ui.modules.inspector
 
+import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.utils.Align
 import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisTable
 import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.AssetSelectedEvent
 import com.mbrlabs.mundus.editor.events.ComponentAddedEvent
 import com.mbrlabs.mundus.editor.events.GameObjectModifiedEvent
@@ -45,6 +47,8 @@ class Inspector : VisTable(),
     enum class InspectorMode {
         GAME_OBJECT, ASSET, EMPTY
     }
+
+    private val projectManager: ProjectManager = Mundus.inject()
 
     private var mode = InspectorMode.EMPTY
     private val root = VisTable()
@@ -72,6 +76,16 @@ class Inspector : VisTable(),
         scrollPane.setFadeScrollBars(false)
 
         add<ScrollPane>(scrollPane).expand().fill().top()
+    }
+
+    override fun act(delta: Float) {
+        super.act(delta)
+
+        // If this widget is visible and the currentSelection variable is null (for example a brush tool selected) then
+        // disable this widget
+        val projectContext = projectManager.current()
+        val touchable = if (projectContext.currScene.currentSelection != null) Touchable.enabled else Touchable.disabled
+        this.touchable = touchable
     }
 
     fun clearWidgets() {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/IdentifierWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/IdentifierWidget.kt
@@ -17,6 +17,7 @@
 package com.mbrlabs.mundus.editor.ui.modules.inspector.components
 
 import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.kotcrab.vis.ui.widget.VisCheckBox
 import com.kotcrab.vis.ui.widget.VisLabel
@@ -42,6 +43,16 @@ class IdentifierWidget : VisTable() {
     init {
         setupUI()
         setupListeners()
+    }
+
+    override fun act(delta: Float) {
+        super.act(delta)
+
+        // If this widget is visible and the currentSelection variable is null (for example a brush tool selected) then
+        // disable this widget
+        val projectContext = projectManager.current()
+        val touchable = if (projectContext.currScene.currentSelection != null) Touchable.enabled else Touchable.disabled
+        this.touchable = touchable
     }
 
     private fun setupUI() {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/TransformWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/TransformWidget.kt
@@ -19,6 +19,7 @@ package com.mbrlabs.mundus.editor.ui.modules.inspector.components
 import com.badlogic.gdx.math.Quaternion
 import com.badlogic.gdx.math.Vector3
 import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.Touchable
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.kotcrab.vis.ui.widget.VisLabel
 import com.mbrlabs.mundus.commons.scene3d.GameObject
@@ -64,6 +65,16 @@ class TransformWidget : BaseInspectorWidget("Transformation") {
         isDeletable = false
         setupUI()
         setupListeners()
+    }
+
+    override fun act(delta: Float) {
+        super.act(delta)
+
+        // If this widget is visible and the currentSelection variable is null (for example a brush tool selected) then
+        // disable this widget
+        val projectContext = projectManager.current()
+        val touchable = if (projectContext.currScene.currentSelection != null) Touchable.enabled else Touchable.disabled
+        this.touchable = touchable
     }
 
     private fun setupUI() {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/BaseBrushTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/BaseBrushTab.kt
@@ -1,23 +1,32 @@
 package com.mbrlabs.mundus.editor.ui.modules.inspector.components.terrain
 
 import com.kotcrab.vis.ui.widget.tabbedpane.Tab
+import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.core.project.ProjectManager
+import com.mbrlabs.mundus.editor.tools.ToolManager
 import com.mbrlabs.mundus.editor.tools.brushes.TerrainBrush
+import com.mbrlabs.mundus.editor.ui.UI
 
 abstract class BaseBrushTab(private val parent: TerrainComponentWidget,
                             private val mode: TerrainBrush.BrushMode)
     : Tab(false, false) {
 
     protected val terrainBrushGrid: TerrainBrushGrid = TerrainBrushGrid(parent, mode);
-
-    override fun onShow() {
-        terrainBrushGrid.setupButtonStyleForSelectedBrush()
-    }
+    private val toolManager: ToolManager = Mundus.inject()
 
     /**
      * Clears selection.
      */
     override fun onHide() {
         super.onHide()
+
+        // Set the active tool to default translate tool if changing tab
+        val projectManager: ProjectManager = Mundus.inject()
+        if (toolManager.activeTool is TerrainBrush) {
+            toolManager.activateTool(toolManager.translateTool)
+            projectManager.current().currScene.currentSelection = UI.outline.getSelectedGameObject()
+        }
+
         terrainBrushGrid.clearSelectedButtonStyle()
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainBrushGrid.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainBrushGrid.kt
@@ -78,18 +78,6 @@ class TerrainBrushGrid(private val parent: TerrainComponentWidget,
         add(settingsTable).expand().fill().padLeft(5f).padRight(5f).padTop(5f).row()
     }
 
-    fun setupButtonStyleForSelectedBrush() {
-        val activeTool = toolManager.activeTool
-
-        if (activeTool is TerrainBrush && activeTool.mode.equals(brushMode)) {
-            for (button in buttons) {
-                if (button.name == activeTool.name) {
-                    button.style = FaTextButton.styleActive
-                }
-            }
-        }
-    }
-
     fun clearSelectedButtonStyle() {
         buttons.forEach { it.style = FaTextButton.styleNoBg }
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainBrushGrid.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainBrushGrid.kt
@@ -27,6 +27,7 @@ import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisTable
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.events.GlobalBrushSettingsChangedEvent
+import com.mbrlabs.mundus.editor.events.ToolActivatedEvent
 import com.mbrlabs.mundus.editor.events.ToolDeactivatedEvent
 import com.mbrlabs.mundus.editor.tools.ToolManager
 import com.mbrlabs.mundus.editor.tools.brushes.TerrainBrush
@@ -40,7 +41,7 @@ import com.mbrlabs.mundus.editor.ui.widgets.ImprovedSlider
  */
 class TerrainBrushGrid(private val parent: TerrainComponentWidget,
                        private val brushMode: TerrainBrush.BrushMode)
-    : VisTable(), GlobalBrushSettingsChangedEvent.GlobalBrushSettingsChangedListener, ToolDeactivatedEvent.ToolDeactivatedEventListener {
+    : VisTable(), GlobalBrushSettingsChangedEvent.GlobalBrushSettingsChangedListener, ToolDeactivatedEvent.ToolDeactivatedEventListener, ToolActivatedEvent.ToolActivatedEventListener {
 
     private val grid = GridGroup(40f, 0f)
     private val strengthSlider = ImprovedSlider(0f, 1f, 0.1f)
@@ -113,6 +114,10 @@ class TerrainBrushGrid(private val parent: TerrainComponentWidget,
         clearSelectedButtonStyle()
     }
 
+    override fun onToolActivatedEvent(event: ToolActivatedEvent) {
+        clearSelectedButtonStyle()
+    }
+
     /**
      */
     private inner class BrushItem(brush: TerrainBrush) : VisTable() {
@@ -123,7 +128,6 @@ class TerrainBrushGrid(private val parent: TerrainComponentWidget,
             buttons.add(button)
             addListener(object : ClickListener() {
                 override fun clicked(event: InputEvent?, x: Float, y: Float) {
-                    clearSelectedButtonStyle()
                     activateBrush(brush)
                     button.style = FaTextButton.styleActive
                 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainPaintTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainPaintTab.kt
@@ -76,6 +76,14 @@ class TerrainPaintTab(private val parentWidget: TerrainComponentWidget) : BaseBr
         setupTextureGrid()
     }
 
+    override fun onShow() {
+        super.onShow()
+
+        // At tab open the first (base) texture will be selected
+        TerrainBrush.setPaintChannel(SplatTexture.Channel.BASE)
+        textureGrid.highlightFirst();
+    }
+
     fun setupAddTextureBrowser() {
         addTextureBtn.addListener(object : ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
@@ -57,7 +57,8 @@ class Outline : VisTable(),
     ProjectChangedEvent.ProjectChangedListener,
     SceneChangedEvent.SceneChangedListener,
     SceneGraphChangedEvent.SceneGraphChangedListener,
-    GameObjectSelectedEvent.GameObjectSelectedListener {
+    GameObjectSelectedEvent.GameObjectSelectedListener,
+    AssetSelectedEvent.AssetSelectedListener {
 
     companion object {
         private val TITLE = "Outline"
@@ -107,6 +108,8 @@ class Outline : VisTable(),
 
     fun clearSelection() {
         tree.selection.clear()
+        projectManager.current().currScene.sceneGraph.selected = null
+        projectManager.current().currScene.currentSelection = null
     }
 
     override fun onProjectChanged(event: ProjectChangedEvent) {
@@ -455,10 +458,10 @@ class Outline : VisTable(),
         tree.selection.clear()
         tree.selection.add(node)
         node.expandTo()
+    }
 
-//        if (toolManager.activeTool !== toolManager.translateTool) {
-//            toolManager.setDefaultTool()
-//        }
+    override fun onAssetSelected(event: AssetSelectedEvent) {
+        clearSelection()
     }
 
     /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
@@ -108,7 +108,6 @@ class Outline : VisTable(),
 
     fun clearSelection() {
         tree.selection.clear()
-        projectManager.current().currScene.sceneGraph.selected = null
         projectManager.current().currScene.currentSelection = null
     }
 
@@ -303,7 +302,6 @@ class Outline : VisTable(),
                 val selection = tree.getSelection()
                 if (selection != null && selection.size() > 0) {
                     val go = selection.first().value
-                    projectManager.current().currScene.sceneGraph.selected = go
                     Mundus.postEvent(GameObjectSelectedEvent(go))
                 }
             }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
@@ -103,6 +103,12 @@ class Outline : VisTable(),
         setupListeners()
     }
 
+    fun getSelectedGameObject(): GameObject? = tree.selectedValue
+
+    fun clearSelection() {
+        tree.selection.clear()
+    }
+
     override fun onProjectChanged(event: ProjectChangedEvent) {
         // update to new sceneGraph
         Log.trace(TAG, "Project changed. Building scene graph.")
@@ -295,7 +301,6 @@ class Outline : VisTable(),
                 if (selection != null && selection.size() > 0) {
                     val go = selection.first().value
                     projectManager.current().currScene.sceneGraph.selected = go
-                    toolManager.translateTool.gameObjectSelected(go)
                     Mundus.postEvent(GameObjectSelectedEvent(go))
                 }
             }
@@ -451,9 +456,9 @@ class Outline : VisTable(),
         tree.selection.add(node)
         node.expandTo()
 
-        if (toolManager.activeTool !== toolManager.translateTool) {
-            toolManager.setDefaultTool()
-        }
+//        if (toolManager.activeTool !== toolManager.translateTool) {
+//            toolManager.setDefaultTool()
+//        }
     }
 
     /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/TextureGrid.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/TextureGrid.java
@@ -17,22 +17,28 @@
 package com.mbrlabs.mundus.editor.ui.widgets;
 
 import com.badlogic.gdx.Input;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.Stack;
+import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.badlogic.gdx.utils.Array;
-import com.kotcrab.vis.ui.VisUI;
 import com.kotcrab.vis.ui.layout.GridGroup;
 import com.kotcrab.vis.ui.widget.VisImage;
 import com.kotcrab.vis.ui.widget.VisTable;
 import com.mbrlabs.mundus.commons.utils.TextureProvider;
+import com.mbrlabs.mundus.editor.utils.Colors;
 
 /**
  * @author Marcus Brummer
  * @version 30-01-2016
  */
 public class TextureGrid<T extends TextureProvider> extends VisTable {
+
+    private static final int HIGHLIGHT_LINE_WIDTH = 3;
 
     private final GridGroup grid;
     private OnTextureClickedListener listener;
@@ -44,8 +50,7 @@ public class TextureGrid<T extends TextureProvider> extends VisTable {
         this.grid = new GridGroup(imgSize, spacing);
         add(grid).expand().fill().row();
 
-        selectedOverlay = new Image(VisUI.getSkin().getDrawable("default-select-selection"));
-        selectedOverlay.getColor().a = 0.6f;
+        selectedOverlay = createSelectedOverlayImage(imgSize);
     }
 
     public TextureGrid(int imgSize, int spacing, Array<T> textures) {
@@ -82,6 +87,25 @@ public class TextureGrid<T extends TextureProvider> extends VisTable {
      */
     public interface OnTextureClickedListener {
         void onTextureSelected(TextureProvider textureProvider, boolean leftClick);
+    }
+
+    private Image createSelectedOverlayImage(final int imgSize) {
+        final Pixmap pixmap = new Pixmap(imgSize, imgSize, Pixmap.Format.RGBA8888);
+        pixmap.setColor(Colors.INSTANCE.getTEAL());
+
+        // Fill top line
+        pixmap.fillRectangle(0, 0, imgSize, HIGHLIGHT_LINE_WIDTH);
+
+        //Fill left line
+        pixmap.fillRectangle(0, 0, HIGHLIGHT_LINE_WIDTH, imgSize);
+
+        // Fill right line
+        pixmap.fillRectangle(imgSize - HIGHLIGHT_LINE_WIDTH, 0, HIGHLIGHT_LINE_WIDTH, imgSize);
+
+        // Fill bottom line
+        pixmap.fillRectangle(0, imgSize - HIGHLIGHT_LINE_WIDTH, imgSize, HIGHLIGHT_LINE_WIDTH);
+
+        return new Image(new TextureRegionDrawable(new TextureRegion(new Texture(pixmap))));
     }
 
     /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/TextureGrid.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/TextureGrid.java
@@ -19,7 +19,10 @@ package com.mbrlabs.mundus.editor.ui.widgets;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
+import com.badlogic.gdx.scenes.scene2d.ui.Image;
+import com.badlogic.gdx.scenes.scene2d.ui.Stack;
 import com.badlogic.gdx.utils.Array;
+import com.kotcrab.vis.ui.VisUI;
 import com.kotcrab.vis.ui.layout.GridGroup;
 import com.kotcrab.vis.ui.widget.VisImage;
 import com.kotcrab.vis.ui.widget.VisTable;
@@ -34,10 +37,15 @@ public class TextureGrid<T extends TextureProvider> extends VisTable {
     private final GridGroup grid;
     private OnTextureClickedListener listener;
 
+    private final Image selectedOverlay;
+
     public TextureGrid(int imgSize, int spacing) {
         super();
         this.grid = new GridGroup(imgSize, spacing);
         add(grid).expand().fill().row();
+
+        selectedOverlay = new Image(VisUI.getSkin().getDrawable("default-select-selection"));
+        selectedOverlay.getColor().a = 0.6f;
     }
 
     public TextureGrid(int imgSize, int spacing, Array<T> textures) {
@@ -64,6 +72,11 @@ public class TextureGrid<T extends TextureProvider> extends VisTable {
         grid.clearChildren();
     }
 
+    public void highlightFirst() {
+        final TextureItem<T> first = (TextureItem<T>) grid.getChildren().first();
+        first.highlight();
+    }
+
     /**
      *
      */
@@ -75,9 +88,14 @@ public class TextureGrid<T extends TextureProvider> extends VisTable {
      *
      */
     private class TextureItem<T extends TextureProvider> extends VisTable {
+
+        private final Stack stack;
+
         public TextureItem(final T tex) {
             super();
-            add(new VisImage(tex.getTexture()));
+            stack = new Stack();
+            stack.add(new VisImage(tex.getTexture()));
+            add(stack);
 
             addListener(new InputListener() {
                 @Override
@@ -88,11 +106,17 @@ public class TextureGrid<T extends TextureProvider> extends VisTable {
                 @Override
                 public void touchUp(InputEvent event, float x, float y, int pointer, int button) {
                     if (listener == null) return;
+                    highlight();
                     listener.onTextureSelected(tex, button == Input.Buttons.LEFT);
                 }
             });
 
         }
+
+        public void highlight() {
+            stack.add(selectedOverlay);
+        }
+
     }
 
 }

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -8,6 +8,7 @@
 - Fix isOnTerrain, getNormalAtWordCoordinate and getHeightAtWorldCoord methods for rotated and scaled terrain
 - Fix frustum culling not handling rotations
 - Fix water reflections when camera is rotated
+- Removed selected field from SceneGraph class
 
 [0.4.0] ~ 10/12/2022
 - [BREAKING CHANGE] The loadScene method for the runtime has changed. A ModelBatch is no longer required to be passed in.


### PR DESCRIPTION
### 1) Clearing selection

Currently if select a game object and press ESC key then the selection is clearing but the game object is selected in the Outline and see it's properties on Inspector. And if change a property in Inspector then it doesn't change on game object.

Before fix:
![clear_selection_before](https://user-images.githubusercontent.com/1684274/234808261-4e4a0314-f0fc-4491-9bee-bb6c9f0bb434.gif)

After fix:
![clear_selection_after](https://user-images.githubusercontent.com/1684274/234808302-c9d37f4d-b614-4cd3-8def-b064bbe59c55.gif)

### 2) Selecting a brush tool
If selected a brush tool on terrain then the previous tool still selected on the toolbar, but not this tool the active. It's misleading. After fix, the previous selected tool (any tool from toolbar, like translate tool, rotate tool, etc) will be deselected.

Before fix:
![terrain_brush_tool_selection_before](https://user-images.githubusercontent.com/1684274/234847329-117d166d-4e0c-4e0d-bc4c-e78e97fd3289.gif)

After fix:
![terrain_brush_tool_selection_after](https://user-images.githubusercontent.com/1684274/234847369-bd4b91f7-5730-4540-8ac6-2bca111619e9.gif)

### 3) Going back from brush tool with ESC key

Currently If selected a terrain brush tool and pressing ESC key then brush tool will be deactivated but the previous tool on toolbar still visible as active but it doesn't active, the wireframe doesn't visible. After fix after pressing ESC key then the translate tool will be active and visible as active.  And if press again ESC, then clear selection, see at 1).

Before fix:
![back_from_brush_tool_with_esc_key_before](https://user-images.githubusercontent.com/1684274/234850878-7246cff0-7279-4f7e-a724-766b18ca6546.gif)

After fix:
![back_from_brush_tool_with_esc_key_after](https://user-images.githubusercontent.com/1684274/234851878-18f58cde-9830-4377-ba47-4181924af7d5.gif)

### 4) Selecting tool from toolbar while in brush tool
Currently if selecting a tool from toolbar while we are using a brush tool then the tool on toolbar will be visible as active but it doesn't active, the wireframe doesn't visible.

Before fix:
![select_tool_from_toolbar_while_in_brush_tool_before](https://user-images.githubusercontent.com/1684274/234876838-90138419-3a44-4b65-b7db-1e308d4d902f.gif)

After fix:
![select_tool_from_toolbar_while_in_brush_tool_after](https://user-images.githubusercontent.com/1684274/234876869-be87d3e4-cb23-467d-9754-1a46d864c086.gif)

### 5) Selecting asset while a tool was selected from toolbar
Currently if selecting an asset from assert dockbar while a tool was selected on a game object then the Outline still shows the previously selected game object and the wireframe still visible but the Inspector shows the asset''s data.

Before fix:
![select_asset_while_toolbar_tool_active_before](https://user-images.githubusercontent.com/1684274/234887643-9b77661c-67a8-4bdb-9e47-f550beec0820.gif)

After fix:
![select_asset_while_toolbar_tool_active_after](https://user-images.githubusercontent.com/1684274/234887696-255e957e-735d-4c2a-86e8-7864e8550080.gif)

### 6) Selecting asset while a terrain brush tool was selected
Currently if selecting an asset while a brush tool was selected then the brush tool still active. 

Before fix:
![select_asset_while_brush_tool_selected_before](https://user-images.githubusercontent.com/1684274/234900170-8f910338-cc3b-4133-8040-deff6b719905.gif)

After fix:
![select_asset_while_brush_tool_selected_after](https://user-images.githubusercontent.com/1684274/234900204-fcf663ed-ac74-4b08-bb0c-60d00b1571ea.gif)

### 7) Editing position/rotation/scale while a terrain brush tool was selected
Currently if editing position or rotation or scale while a terrain brush tool was selected then nothing happens. After fix the whole transformation widget will be disabled if a brush tool was selected. 

Before fix:
![edititng_transformation_while_in_brush_tool_before](https://user-images.githubusercontent.com/1684274/235238932-1f1f8bd1-68e7-4f11-a1cb-061873571d0c.gif)

After fix:
![edititng_transformation_while_in_brush_tool_after](https://user-images.githubusercontent.com/1684274/235340834-368d8019-62ed-411f-b8da-38bc9603020f.gif)

### 8) Changing tab on terrain component widget after selected a brush tool
Currently if selected brush tool on a tab on terrain component widget and changing tab the selected tool still active and you don't see what tool active at the moment. After fix if changing tab on terrain component widget then the active tool will be the default translate tool.

Before fix:
![changing_tab_after_selected_brush_tool_before](https://user-images.githubusercontent.com/1684274/235322960-988066eb-bbc3-40c7-8455-838e10f95f13.gif)

After fix:
![changing_tab_after_selected_brush_tool_after](https://user-images.githubusercontent.com/1684274/235351076-2bc492f4-d4c5-418e-986f-1dbd01484a25.gif)

### 9) Editing name/visibility/tag while a terrain brush tool was selected
Similar to 7). Currently if editing name, visibility or tag in identifier widget while a terrain brush tool was selected then nothing happens. After fix the whole identifier widget will be disabled if a brush tool was selected. 

Before fix:
![editing_field_in_inspector_while_in_brush_tool_before](https://user-images.githubusercontent.com/1684274/235351479-87d3d3a3-4e6c-4633-9a68-523c276b6285.gif)

After fix:
![editing_field_in_inspector_while_in_brush_tool_after](https://user-images.githubusercontent.com/1684274/235351669-b878d0dc-5a76-42c8-92ca-0ed4ce2927fe.gif)

### 10) Missing highlight for selected texture on paint tab.
Currently if want to paint on a terrain the currently selected texture is not highlighted. After fix at paint tab open the first texture will be selected and highlighted and if select a texture it will be highlighted. 

Before fix:
![missing_highlight_for_selected_texture_on_paint_tab_before](https://user-images.githubusercontent.com/1684274/235352968-9f4b67bd-0007-4aa5-806e-7fcf70b8fcf1.gif)

After fix:
![missing_highlight_for_selected_texture_on_paint_tab_after](https://user-images.githubusercontent.com/1684274/235409515-2fb8ee99-f000-4480-8af1-f449b47ae50d.gif)


