### PR TITLE
Custom properties for game objects

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/dto/CustomPropertiesComponentDTO.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/dto/CustomPropertiesComponentDTO.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.commons.dto;
+
+import com.badlogic.gdx.utils.OrderedMap;
+
+public class CustomPropertiesComponentDTO {
+
+    private OrderedMap<String, String> customProperties;
+
+    public OrderedMap<String, String> getCustomProperties() {
+        return customProperties;
+    }
+
+    public void setCustomProperties(final OrderedMap<String, String> customProperties) {
+        this.customProperties = customProperties;
+    }
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/dto/GameObjectDTO.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/dto/GameObjectDTO.java
@@ -37,6 +37,7 @@ public class GameObjectDTO {
     private TerrainComponentDTO terrainComponent;
     private WaterComponentDTO waterComponent;
     private LightComponentDTO lightComponent;
+    private CustomPropertiesComponentDTO customPropertiesComponent;
 
     public GameObjectDTO() {
         childs = new Array<>();
@@ -117,5 +118,13 @@ public class GameObjectDTO {
 
     public void setLightComponent(LightComponentDTO lightComponent) {
         this.lightComponent = lightComponent;
+    }
+
+    public CustomPropertiesComponentDTO getCustomPropertiesComponent() {
+        return customPropertiesComponent;
+    }
+
+    public void setCustomPropertiesComponent(final CustomPropertiesComponentDTO customPropertiesComponent) {
+        this.customPropertiesComponent = customPropertiesComponent;
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/mapper/CustomPropertiesComponentConverter.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/mapper/CustomPropertiesComponentConverter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.commons.mapper;
+
+import com.badlogic.gdx.utils.ObjectMap;
+import com.mbrlabs.mundus.commons.dto.CustomPropertiesComponentDTO;
+import com.mbrlabs.mundus.commons.scene3d.GameObject;
+import com.mbrlabs.mundus.commons.scene3d.components.CustomPropertiesComponent;
+
+public class CustomPropertiesComponentConverter {
+
+    public static CustomPropertiesComponent convert(final CustomPropertiesComponentDTO dto, final GameObject go) {
+        final CustomPropertiesComponent component = new CustomPropertiesComponent(go);
+        component.getCustomProperties().putAll((ObjectMap<? extends String, ? extends String>) dto.getCustomProperties());
+
+        return component;
+    }
+
+    public static CustomPropertiesComponentDTO convert(final CustomPropertiesComponent component) {
+        final CustomPropertiesComponentDTO dto = new CustomPropertiesComponentDTO();
+        dto.setCustomProperties(component.getCustomProperties());
+
+        return dto;
+    }
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/mapper/CustomPropertiesComponentConverter.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/mapper/CustomPropertiesComponentConverter.java
@@ -16,7 +16,7 @@
 
 package com.mbrlabs.mundus.commons.mapper;
 
-import com.badlogic.gdx.utils.ObjectMap;
+import com.badlogic.gdx.utils.OrderedMap;
 import com.mbrlabs.mundus.commons.dto.CustomPropertiesComponentDTO;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.components.CustomPropertiesComponent;
@@ -25,7 +25,11 @@ public class CustomPropertiesComponentConverter {
 
     public static CustomPropertiesComponent convert(final CustomPropertiesComponentDTO dto, final GameObject go) {
         final CustomPropertiesComponent component = new CustomPropertiesComponent(go);
-        component.getMap().putAll((ObjectMap<? extends String, ? extends String>) dto.getCustomProperties());
+        final OrderedMap<String, String> dtoMap = dto.getCustomProperties();
+
+        for (final OrderedMap.Entry<String, String> entry : dtoMap.iterator()) {
+            component.put(entry.key, entry.value);
+        }
 
         return component;
     }

--- a/commons/src/main/com/mbrlabs/mundus/commons/mapper/CustomPropertiesComponentConverter.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/mapper/CustomPropertiesComponentConverter.java
@@ -25,14 +25,14 @@ public class CustomPropertiesComponentConverter {
 
     public static CustomPropertiesComponent convert(final CustomPropertiesComponentDTO dto, final GameObject go) {
         final CustomPropertiesComponent component = new CustomPropertiesComponent(go);
-        component.getCustomProperties().putAll((ObjectMap<? extends String, ? extends String>) dto.getCustomProperties());
+        component.getMap().putAll((ObjectMap<? extends String, ? extends String>) dto.getCustomProperties());
 
         return component;
     }
 
     public static CustomPropertiesComponentDTO convert(final CustomPropertiesComponent component) {
         final CustomPropertiesComponentDTO dto = new CustomPropertiesComponentDTO();
-        dto.setCustomProperties(component.getCustomProperties());
+        dto.setCustomProperties(component.getMap());
 
         return dto;
     }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
@@ -19,6 +19,7 @@ package com.mbrlabs.mundus.commons.scene3d;
 import com.badlogic.gdx.graphics.g3d.Shader;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ObjectMap;
 import com.mbrlabs.mundus.commons.scene3d.components.ClippableComponent;
 import com.mbrlabs.mundus.commons.scene3d.components.Component;
 import com.mbrlabs.mundus.commons.scene3d.components.LightComponent;
@@ -42,6 +43,7 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
     public boolean hasWaterComponent = false;
     private Array<String> tags;
     private Array<Component> components;
+    private ObjectMap<String, String> customProperties;
 
     public final SceneGraph sceneGraph;
 
@@ -60,6 +62,7 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
         this.active = true;
         this.tags = null;
         this.components = new Array<Component>(3);
+        this.customProperties = null;
     }
 
     /**
@@ -198,6 +201,14 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
         }
 
         this.tags.add(tag);
+    }
+
+    public ObjectMap<String, String> getCustomProperties() {
+        if (customProperties == null) {
+            customProperties = new ObjectMap<>();
+        }
+
+        return this.customProperties;
     }
 
     /**

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
@@ -19,7 +19,6 @@ package com.mbrlabs.mundus.commons.scene3d;
 import com.badlogic.gdx.graphics.g3d.Shader;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.ObjectMap;
 import com.mbrlabs.mundus.commons.scene3d.components.ClippableComponent;
 import com.mbrlabs.mundus.commons.scene3d.components.Component;
 import com.mbrlabs.mundus.commons.scene3d.components.LightComponent;
@@ -43,7 +42,6 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
     public boolean hasWaterComponent = false;
     private Array<String> tags;
     private Array<Component> components;
-    private ObjectMap<String, String> customProperties;
 
     public final SceneGraph sceneGraph;
 
@@ -62,7 +60,6 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
         this.active = true;
         this.tags = null;
         this.components = new Array<Component>(3);
-        this.customProperties = null;
     }
 
     /**
@@ -201,14 +198,6 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
         }
 
         this.tags.add(tag);
-    }
-
-    public ObjectMap<String, String> getCustomProperties() {
-        if (customProperties == null) {
-            customProperties = new ObjectMap<>();
-        }
-
-        return this.customProperties;
     }
 
     /**

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/Component.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/Component.java
@@ -26,7 +26,7 @@ import com.mbrlabs.mundus.commons.scene3d.GameObject;
 public interface Component {
 
     enum Type {
-        MODEL, TERRAIN, LIGHT, PARTICLE_SYSTEM, WATER
+        MODEL, TERRAIN, LIGHT, PARTICLE_SYSTEM, WATER, CUSTOM_PROPERTIES
     }
 
     GameObject getGameObject();

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CustomPropertiesComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CustomPropertiesComponent.java
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.commons.scene3d.components;
 
+import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.OrderedMap;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 
@@ -41,7 +42,9 @@ public class CustomPropertiesComponent extends AbstractComponent {
 
     @Override
     public Component clone(final GameObject go) {
-        return null;
+        final CustomPropertiesComponent component = new CustomPropertiesComponent(go);
+        component.customProperties.putAll((ObjectMap<? extends String, ? extends String>) this.customProperties);
+        return component;
     }
 
     /**

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CustomPropertiesComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CustomPropertiesComponent.java
@@ -44,7 +44,45 @@ public class CustomPropertiesComponent extends AbstractComponent {
         return null;
     }
 
-    public OrderedMap<String, String> getCustomProperties() {
+    /**
+     * See {@link OrderedMap#containsKey(Object)}.
+     */
+    public boolean containsKey(String key) {
+        return customProperties.containsKey(key);
+    }
+
+    /**
+     * See {@link OrderedMap#get(Object)}.
+     */
+    public String get(String key) {
+        return customProperties.get(key);
+    }
+
+    /**
+     * See {@link OrderedMap#put(Object, Object)}.
+     */
+    public String put(String key, String value) {
+        return customProperties.put(key, value);
+    }
+
+    /**
+     * See {@link OrderedMap#remove(Object)}.
+     */
+    public String remove(String key) {
+        return customProperties.remove(key);
+    }
+
+    /**
+     * @return Size of custom properties map.
+     */
+    public int getSize() {
+        return customProperties.size;
+    }
+
+    /**
+     * @return The whole custom properties map.
+     */
+    public OrderedMap<String, String> getMap() {
         return customProperties;
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CustomPropertiesComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CustomPropertiesComponent.java
@@ -1,0 +1,34 @@
+package com.mbrlabs.mundus.commons.scene3d.components;
+
+import com.badlogic.gdx.utils.OrderedMap;
+import com.mbrlabs.mundus.commons.scene3d.GameObject;
+
+public class CustomPropertiesComponent extends AbstractComponent {
+
+    private final OrderedMap<String, String> customProperties;
+
+    public CustomPropertiesComponent(final GameObject go) {
+        super(go);
+        this.customProperties = new OrderedMap<>(5);
+        type = Type.CUSTOM_PROPERTIES;
+    }
+
+    @Override
+    public void render(final float delta) {
+        // NOOP
+    }
+
+    @Override
+    public void update(final float delta) {
+        // NOOP
+    }
+
+    @Override
+    public Component clone(final GameObject go) {
+        return null;
+    }
+
+    public OrderedMap<String, String> getCustomProperties() {
+        return customProperties;
+    }
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CustomPropertiesComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CustomPropertiesComponent.java
@@ -16,7 +16,6 @@
 
 package com.mbrlabs.mundus.commons.scene3d.components;
 
-import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.OrderedMap;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 
@@ -43,7 +42,11 @@ public class CustomPropertiesComponent extends AbstractComponent {
     @Override
     public Component clone(final GameObject go) {
         final CustomPropertiesComponent component = new CustomPropertiesComponent(go);
-        component.customProperties.putAll((ObjectMap<? extends String, ? extends String>) this.customProperties);
+
+        for (final OrderedMap.Entry<String, String> entry : this.customProperties.iterator()) {
+            component.put(entry.key, entry.value);
+        }
+
         return component;
     }
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CustomPropertiesComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CustomPropertiesComponent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2023. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mbrlabs.mundus.commons.scene3d.components;
 
 import com.badlogic.gdx.utils.OrderedMap;

--- a/commons/src/main/commons.gwt.xml
+++ b/commons/src/main/commons.gwt.xml
@@ -10,6 +10,7 @@
     <extend-configuration-property name="gdx.reflect.include" value="com.mbrlabs.mundus.commons.dto.TerrainComponentDTO" />
     <extend-configuration-property name="gdx.reflect.include" value="com.mbrlabs.mundus.commons.dto.BaseLightDTO" />
     <extend-configuration-property name="gdx.reflect.include" value="com.mbrlabs.mundus.commons.dto.LightComponentDTO" />
+    <extend-configuration-property name="gdx.reflect.include" value="com.mbrlabs.mundus.commons.dto.CustomPropertiesComponentDTO" />
     <extend-configuration-property name="gdx.reflect.include" value="com.mbrlabs.mundus.commons.dto.DirectionalLightDTO" />
     <extend-configuration-property name="gdx.reflect.include" value="com.mbrlabs.mundus.commons.dto.ShadowSettingsDTO" />
     <extend-configuration-property name="gdx.reflect.include" value="com.mbrlabs.mundus.commons.dto.FogDTO" />

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -20,6 +20,7 @@
 - Water creation dialog
 - Helper lines
 - Show renamed game object's new name after rename in Inspector
+- Custom properties component addable to game objects
 
 [0.4.2] ~ 10/24/2022
 - Fix shader compilation error for Terrain when using normal maps

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/converter/GameObjectConverter.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/converter/GameObjectConverter.java
@@ -20,9 +20,11 @@ import com.badlogic.gdx.math.Quaternion;
 import com.badlogic.gdx.math.Vector3;
 import com.mbrlabs.mundus.commons.assets.Asset;
 import com.mbrlabs.mundus.commons.dto.GameObjectDTO;
+import com.mbrlabs.mundus.commons.mapper.CustomPropertiesComponentConverter;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
 import com.mbrlabs.mundus.commons.scene3d.components.Component;
+import com.mbrlabs.mundus.commons.scene3d.components.CustomPropertiesComponent;
 import com.mbrlabs.mundus.commons.scene3d.components.LightComponent;
 import com.mbrlabs.mundus.editor.Mundus;
 import com.mbrlabs.mundus.editor.events.ComponentAddedEvent;
@@ -68,6 +70,11 @@ public class GameObjectConverter {
             go.getComponents().add(TerrainComponentConverter.convert(dto.getTerrainComponent(), go, assets));
         } else if (dto.getWaterComponent() != null) {
             go.getComponents().add(WaterComponentConverter.convert(dto.getWaterComponent(), go, assets));
+        }
+
+        // Convert custom properties component
+        if (dto.getCustomPropertiesComponent() != null) {
+            go.getComponents().add(CustomPropertiesComponentConverter.convert(dto.getCustomPropertiesComponent(), go));
         }
 
         // Convert light component
@@ -127,6 +134,8 @@ public class GameObjectConverter {
                 descriptor.setWaterComponent(WaterComponentConverter.convert((PickableWaterComponent) c));
             } else if (c.getType() == Component.Type.LIGHT) {
                 descriptor.setLightComponent(PickableLightComponentConverter.convert((LightComponent) c));
+            } else if (c.getType() == Component.Type.CUSTOM_PROPERTIES) {
+                descriptor.setCustomPropertiesComponent(CustomPropertiesComponentConverter.convert((CustomPropertiesComponent) c));
             }
         }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddComponentDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddComponentDialog.kt
@@ -12,6 +12,7 @@ import com.mbrlabs.mundus.commons.env.lights.LightType
 import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.commons.scene3d.InvalidComponentException
 import com.mbrlabs.mundus.commons.scene3d.components.Component
+import com.mbrlabs.mundus.commons.scene3d.components.CustomPropertiesComponent
 import com.mbrlabs.mundus.commons.utils.LightUtils
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
@@ -48,8 +49,9 @@ class AddComponentDialog : BaseDialog("Add Component") {
         // Load types into select box
         val addableTypes = Array<Component.Type>()
 
-        // At the moment, only light components are supported for dynamically adding
+        // At the moment, only light and custom properties components are supported for dynamically adding
         addableTypes.add(Component.Type.LIGHT)
+        addableTypes.add(Component.Type.CUSTOM_PROPERTIES)
 
         selectBox.items = addableTypes
 
@@ -87,6 +89,7 @@ class AddComponentDialog : BaseDialog("Add Component") {
             Component.Type.LIGHT -> return getNewLightComponent(go)
             Component.Type.PARTICLE_SYSTEM -> TODO()
             Component.Type.WATER -> TODO()
+            Component.Type.CUSTOM_PROPERTIES -> return getNewCustomPropertiesComponent(go)
         }
     }
 
@@ -108,6 +111,14 @@ class AddComponentDialog : BaseDialog("Add Component") {
             Dialogs.showOKDialog(UI, "Info", str)
             return null
         }
+    }
+
+    private fun getNewCustomPropertiesComponent(go: GameObject): Component? {
+        if (go.findComponentByType(Component.Type.CUSTOM_PROPERTIES) == null) {
+            return CustomPropertiesComponent(go)
+        }
+
+        return null
     }
 
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddComponentDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddComponentDialog.kt
@@ -114,11 +114,7 @@ class AddComponentDialog : BaseDialog("Add Component") {
     }
 
     private fun getNewCustomPropertiesComponent(go: GameObject): Component? {
-        if (go.findComponentByType(Component.Type.CUSTOM_PROPERTIES) == null) {
-            return CustomPropertiesComponent(go)
-        }
-
-        return null
+        return CustomPropertiesComponent(go)
     }
 
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/GameObjectInspector.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/GameObjectInspector.kt
@@ -30,6 +30,7 @@ import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
 import com.mbrlabs.mundus.commons.scene3d.components.WaterComponent
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.modules.inspector.components.ComponentWidget
+import com.mbrlabs.mundus.editor.ui.modules.inspector.components.CustomPropertiesWidget
 import com.mbrlabs.mundus.editor.ui.modules.inspector.components.IdentifierWidget
 import com.mbrlabs.mundus.editor.ui.modules.inspector.components.LightComponentWidget
 import com.mbrlabs.mundus.editor.ui.modules.inspector.components.ModelComponentWidget
@@ -48,6 +49,7 @@ class GameObjectInspector : VisTable() {
     private val componentWidgets: Array<ComponentWidget<*>> = Array()
     private val addComponentBtn = VisTextButton("Add Component")
     private val componentTable = VisTable()
+    private val customPropertiesWidget = CustomPropertiesWidget()
 
     private var gameObject: GameObject? = null
 
@@ -66,6 +68,8 @@ class GameObjectInspector : VisTable() {
                 UI.showDialog(UI.addComponentDialog)
             }
         })
+
+        add(customPropertiesWidget).growX().pad(7f).row()
     }
 
     fun setGameObject(gameObject: GameObject) {
@@ -90,6 +94,8 @@ class GameObjectInspector : VisTable() {
             for (cw in componentWidgets) {
                 cw.setValues(gameObject!!)
             }
+
+            customPropertiesWidget.setValues(gameObject!!)
         }
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/GameObjectInspector.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/GameObjectInspector.kt
@@ -24,6 +24,7 @@ import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
 import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.commons.scene3d.components.Component
+import com.mbrlabs.mundus.commons.scene3d.components.CustomPropertiesComponent
 import com.mbrlabs.mundus.commons.scene3d.components.LightComponent
 import com.mbrlabs.mundus.commons.scene3d.components.ModelComponent
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
@@ -37,6 +38,7 @@ import com.mbrlabs.mundus.editor.ui.modules.inspector.components.ModelComponentW
 import com.mbrlabs.mundus.editor.ui.modules.inspector.components.TransformWidget
 import com.mbrlabs.mundus.editor.ui.modules.inspector.components.terrain.TerrainComponentWidget
 import com.mbrlabs.mundus.editor.ui.modules.inspector.components.WaterComponentWidget
+import sun.java2d.loops.CustomComponent
 
 /**
  * @author Marcus Brummer
@@ -49,7 +51,6 @@ class GameObjectInspector : VisTable() {
     private val componentWidgets: Array<ComponentWidget<*>> = Array()
     private val addComponentBtn = VisTextButton("Add Component")
     private val componentTable = VisTable()
-    private val customPropertiesWidget = CustomPropertiesWidget()
 
     private var gameObject: GameObject? = null
 
@@ -68,8 +69,6 @@ class GameObjectInspector : VisTable() {
                 UI.showDialog(UI.addComponentDialog)
             }
         })
-
-        add(customPropertiesWidget).growX().pad(7f).row()
     }
 
     fun setGameObject(gameObject: GameObject) {
@@ -94,8 +93,6 @@ class GameObjectInspector : VisTable() {
             for (cw in componentWidgets) {
                 cw.setValues(gameObject!!)
             }
-
-            customPropertiesWidget.setValues(gameObject!!)
         }
     }
 
@@ -113,6 +110,8 @@ class GameObjectInspector : VisTable() {
                     componentWidgets.add(WaterComponentWidget(component as WaterComponent))
                 } else if (component.type == Component.Type.LIGHT) {
                     componentWidgets.add(LightComponentWidget(component as LightComponent))
+                } else if (component.type == Component.Type.CUSTOM_PROPERTIES) {
+                    componentWidgets.add(CustomPropertiesWidget(component as CustomPropertiesComponent))
                 }
             }
         }
@@ -128,6 +127,9 @@ class GameObjectInspector : VisTable() {
 
         if (component is LightComponent) {
             componentWidgets.add(LightComponentWidget(component))
+            componentTable.add(componentWidgets.last()).grow().row()
+        } else if (component is CustomPropertiesComponent) {
+            componentWidgets.add(CustomPropertiesWidget(component))
             componentTable.add(componentWidgets.last()).grow().row()
         }
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/GameObjectInspector.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/GameObjectInspector.kt
@@ -38,7 +38,6 @@ import com.mbrlabs.mundus.editor.ui.modules.inspector.components.ModelComponentW
 import com.mbrlabs.mundus.editor.ui.modules.inspector.components.TransformWidget
 import com.mbrlabs.mundus.editor.ui.modules.inspector.components.terrain.TerrainComponentWidget
 import com.mbrlabs.mundus.editor.ui.modules.inspector.components.WaterComponentWidget
-import sun.java2d.loops.CustomComponent
 
 /**
  * @author Marcus Brummer

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
@@ -1,16 +1,21 @@
 package com.mbrlabs.mundus.editor.ui.modules.inspector.components
 
+import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.InputEvent
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
 import com.kotcrab.vis.ui.widget.VisTextField
 import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.editor.ui.modules.inspector.BaseInspectorWidget
+import com.mbrlabs.mundus.editor.ui.widgets.FaTextButton
+import com.mbrlabs.mundus.editor.utils.Fa
 
 class CustomPropertiesWidget : BaseInspectorWidget("Custom Properties") {
 
     private val customProperties = VisTable()
+    private var gameObject: GameObject? = null
 
     init {
         isDeletable = false
@@ -22,9 +27,14 @@ class CustomPropertiesWidget : BaseInspectorWidget("Custom Properties") {
     }
 
     override fun setValues(go: GameObject) {
+        this.gameObject = go
+        val goCustomProperties = go.customProperties
+
         customProperties.clearChildren()
 
-        // TODO add custom properties
+        for (entry in goCustomProperties) {
+            addCustomProperty(entry.key, entry.value)
+        }
     }
 
     private fun setupUI() {
@@ -35,8 +45,46 @@ class CustomPropertiesWidget : BaseInspectorWidget("Custom Properties") {
 
         addButton.addListener(object : ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
-                customProperties.add(VisTextField()).padBottom(3f).padRight(3f)
-                customProperties.add(VisTextField()).padBottom(3f).row()
+                val key = ""
+                val value = ""
+                gameObject!!.customProperties.put(key, value)
+                addCustomProperty(key, value)
+            }
+        })
+    }
+
+    private fun addCustomProperty(key: String, value: String) {
+        var previousKey = key
+
+        val keyTextField = VisTextField(key)
+        val valueTextField = VisTextField(value)
+        val deleteButton = FaTextButton(Fa.TIMES)
+
+        customProperties.add(keyTextField).padBottom(3f).padRight(3f)
+        customProperties.add(valueTextField).padBottom(3f).padRight(3f)
+        customProperties.add(deleteButton).row()
+
+        keyTextField.addListener(object : ChangeListener() {
+            override fun changed(event: ChangeEvent, actor: Actor) {
+                val currentKey = keyTextField.text
+
+                val goCustomProperties = gameObject!!.customProperties
+
+                goCustomProperties.remove(previousKey)
+                goCustomProperties.put(currentKey, valueTextField.text)
+
+                previousKey = currentKey
+            }
+        })
+
+        valueTextField.addListener(object : ChangeListener() {
+            override fun changed(event: ChangeEvent?, actor: Actor?) {
+                val currentKey = keyTextField.text
+                val currentValue = valueTextField.text
+
+                val goCustomProperties = gameObject!!.customProperties
+
+                goCustomProperties.put(currentKey, currentValue)
             }
         })
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
@@ -8,31 +8,34 @@ import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
 import com.kotcrab.vis.ui.widget.VisTextField
 import com.mbrlabs.mundus.commons.scene3d.GameObject
-import com.mbrlabs.mundus.editor.ui.modules.inspector.BaseInspectorWidget
+import com.mbrlabs.mundus.commons.scene3d.components.Component
+import com.mbrlabs.mundus.commons.scene3d.components.CustomPropertiesComponent
 import com.mbrlabs.mundus.editor.ui.widgets.FaTextButton
 import com.mbrlabs.mundus.editor.utils.Fa
 
-class CustomPropertiesWidget : BaseInspectorWidget("Custom Properties") {
+class CustomPropertiesWidget(customPropertiesComponent: CustomPropertiesComponent)
+    : ComponentWidget<CustomPropertiesComponent>("Custom Properties Component", customPropertiesComponent) {
 
     private val customProperties = VisTable()
-    private var gameObject: GameObject? = null
 
     init {
-        isDeletable = false
+        component = customPropertiesComponent
 
         setupUI()
     }
     override fun onDelete() {
-        // The custom properties component can't be deleted.
+
     }
 
     override fun setValues(go: GameObject) {
-        this.gameObject = go
-        val goCustomProperties = go.customProperties
+        val c = go.findComponentByType(Component.Type.CUSTOM_PROPERTIES)
+        if (c != null) {
+            component = c as CustomPropertiesComponent
+        }
 
         customProperties.clearChildren()
 
-        for (entry in goCustomProperties) {
+        for (entry in component.customProperties) {
             addCustomProperty(entry.key, entry.value)
         }
     }
@@ -47,7 +50,7 @@ class CustomPropertiesWidget : BaseInspectorWidget("Custom Properties") {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 val key = ""
                 val value = ""
-                gameObject!!.customProperties.put(key, value)
+                component.customProperties.put(key, value)
                 addCustomProperty(key, value)
             }
         })
@@ -68,10 +71,10 @@ class CustomPropertiesWidget : BaseInspectorWidget("Custom Properties") {
             override fun changed(event: ChangeEvent, actor: Actor) {
                 val currentKey = keyTextField.text
 
-                val goCustomProperties = gameObject!!.customProperties
+                val customProperties = component.customProperties
 
-                goCustomProperties.remove(previousKey)
-                goCustomProperties.put(currentKey, valueTextField.text)
+                customProperties.remove(previousKey)
+                customProperties.put(currentKey, valueTextField.text)
 
                 previousKey = currentKey
             }
@@ -82,9 +85,9 @@ class CustomPropertiesWidget : BaseInspectorWidget("Custom Properties") {
                 val currentKey = keyTextField.text
                 val currentValue = valueTextField.text
 
-                val goCustomProperties = gameObject!!.customProperties
+                val customProperties = component.customProperties
 
-                goCustomProperties.put(currentKey, currentValue)
+                customProperties.put(currentKey, currentValue)
             }
         })
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
@@ -24,9 +24,6 @@ class CustomPropertiesWidget(customPropertiesComponent: CustomPropertiesComponen
 
         setupUI()
     }
-    override fun onDelete() {
-
-    }
 
     override fun setValues(go: GameObject) {
         val c = go.findComponentByType(Component.Type.CUSTOM_PROPERTIES)

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
@@ -4,6 +4,7 @@ import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
+import com.badlogic.gdx.scenes.scene2d.utils.FocusListener
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
 import com.kotcrab.vis.ui.widget.VisTextField
@@ -76,10 +77,30 @@ class CustomPropertiesWidget(customPropertiesComponent: CustomPropertiesComponen
 
                 val customProperties = component.customProperties
 
-                customProperties.remove(previousKey)
-                customProperties.put(currentKey, valueTextField.text)
+                if (previousKey == currentKey) {
+                    keyTextField.isInputValid = true
+                } else {
+                    if (customProperties.containsKey(currentKey)) {
+                        keyTextField.isInputValid = false
+                    } else {
+                        keyTextField.isInputValid = true
 
-                previousKey = currentKey
+                        customProperties.remove(previousKey)
+                        customProperties.put(currentKey, valueTextField.text)
+
+                        previousKey = currentKey
+                    }
+                }
+            }
+        })
+
+        keyTextField.addListener(object : FocusListener() {
+            override fun keyboardFocusChanged(event: FocusEvent?, actor: Actor?, focused: Boolean) {
+                // If the key value is invalid then change text to the previous valid value
+                if (!focused && !keyTextField.isInputValid) {
+                    keyTextField.text = previousKey
+                    keyTextField.isInputValid = true
+                }
             }
         })
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
@@ -5,6 +5,8 @@ import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
 import com.badlogic.gdx.scenes.scene2d.utils.FocusListener
+import com.badlogic.gdx.utils.Align
+import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
 import com.kotcrab.vis.ui.widget.VisTextField
@@ -33,6 +35,10 @@ class CustomPropertiesWidget(customPropertiesComponent: CustomPropertiesComponen
 
         customProperties.clearChildren()
 
+        if (component.customProperties.notEmpty()) {
+            addHeader()
+        }
+
         for (entry in component.customProperties) {
             addCustomProperty(entry.key, entry.value)
         }
@@ -51,10 +57,20 @@ class CustomPropertiesWidget(customPropertiesComponent: CustomPropertiesComponen
 
                 if (!component.customProperties.containsKey(key)) {
                     component.customProperties.put(key, value)
+
+                    if (component.customProperties.size == 1) {
+                        addHeader()
+                    }
+
                     addCustomProperty(key, value)
                 }
             }
         })
+    }
+
+    private fun addHeader() {
+        customProperties.add(VisLabel("Key")).expandX().align(Align.center).padBottom(3f).padRight(3f)
+        customProperties.add(VisLabel("Value")).expandX().align(Align.center).padBottom(3f).padRight(3f).row()
     }
 
     private fun addCustomProperty(key: String, value: String) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
@@ -90,5 +90,14 @@ class CustomPropertiesWidget(customPropertiesComponent: CustomPropertiesComponen
                 customProperties.put(currentKey, currentValue)
             }
         })
+
+        deleteButton.addListener(object : ClickListener() {
+            override fun clicked(event: InputEvent?, x: Float, y: Float) {
+                val currentKey = keyTextField.text
+
+                component.customProperties.remove(currentKey)
+                setValues(component.gameObject)
+            }
+        })
     }
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
@@ -50,8 +50,11 @@ class CustomPropertiesWidget(customPropertiesComponent: CustomPropertiesComponen
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 val key = ""
                 val value = ""
-                component.customProperties.put(key, value)
-                addCustomProperty(key, value)
+
+                if (!component.customProperties.containsKey(key)) {
+                    component.customProperties.put(key, value)
+                    addCustomProperty(key, value)
+                }
             }
         })
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
@@ -1,18 +1,43 @@
 package com.mbrlabs.mundus.editor.ui.modules.inspector.components
 
+import com.badlogic.gdx.scenes.scene2d.InputEvent
+import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
+import com.kotcrab.vis.ui.widget.VisTable
+import com.kotcrab.vis.ui.widget.VisTextButton
+import com.kotcrab.vis.ui.widget.VisTextField
 import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.editor.ui.modules.inspector.BaseInspectorWidget
 
 class CustomPropertiesWidget : BaseInspectorWidget("Custom Properties") {
 
+    private val customProperties = VisTable()
+
     init {
         isDeletable = false
+
+        setupUI()
     }
     override fun onDelete() {
         // The custom properties component can't be deleted.
     }
 
     override fun setValues(go: GameObject) {
-        // TODO
+        customProperties.clearChildren()
+
+        // TODO add custom properties
+    }
+
+    private fun setupUI() {
+        collapsibleContent.add(customProperties).row()
+
+        val addButton = VisTextButton("Add")
+        collapsibleContent.add(addButton)
+
+        addButton.addListener(object : ClickListener() {
+            override fun clicked(event: InputEvent?, x: Float, y: Float) {
+                customProperties.add(VisTextField()).padBottom(3f).padRight(3f)
+                customProperties.add(VisTextField()).padBottom(3f).row()
+            }
+        })
     }
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
@@ -51,11 +51,11 @@ class CustomPropertiesWidget(customPropertiesComponent: CustomPropertiesComponen
 
         customProperties.clearChildren()
 
-        if (component.customProperties.notEmpty()) {
+        if (component.map.notEmpty()) {
             addHeader()
         }
 
-        for (entry in component.customProperties) {
+        for (entry in component.map) {
             addCustomProperty(entry.key, entry.value)
         }
     }
@@ -71,10 +71,10 @@ class CustomPropertiesWidget(customPropertiesComponent: CustomPropertiesComponen
                 val key = ""
                 val value = ""
 
-                if (!component.customProperties.containsKey(key)) {
-                    component.customProperties.put(key, value)
+                if (!component.containsKey(key)) {
+                    component.put(key, value)
 
-                    if (component.customProperties.size == 1) {
+                    if (component.size == 1) {
                         addHeader()
                     }
 
@@ -104,18 +104,16 @@ class CustomPropertiesWidget(customPropertiesComponent: CustomPropertiesComponen
             override fun changed(event: ChangeEvent, actor: Actor) {
                 val currentKey = keyTextField.text
 
-                val customProperties = component.customProperties
-
                 if (previousKey == currentKey) {
                     keyTextField.isInputValid = true
                 } else {
-                    if (customProperties.containsKey(currentKey)) {
+                    if (component.containsKey(currentKey)) {
                         keyTextField.isInputValid = false
                     } else {
                         keyTextField.isInputValid = true
 
-                        customProperties.remove(previousKey)
-                        customProperties.put(currentKey, valueTextField.text)
+                        component.remove(previousKey)
+                        component.put(currentKey, valueTextField.text)
 
                         previousKey = currentKey
                     }
@@ -138,9 +136,7 @@ class CustomPropertiesWidget(customPropertiesComponent: CustomPropertiesComponen
                 val currentKey = keyTextField.text
                 val currentValue = valueTextField.text
 
-                val customProperties = component.customProperties
-
-                customProperties.put(currentKey, currentValue)
+                component.put(currentKey, currentValue)
             }
         })
 
@@ -148,7 +144,7 @@ class CustomPropertiesWidget(customPropertiesComponent: CustomPropertiesComponen
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 val currentKey = keyTextField.text
 
-                component.customProperties.remove(currentKey)
+                component.remove(currentKey)
                 setValues(component.gameObject)
             }
         })

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
@@ -1,0 +1,18 @@
+package com.mbrlabs.mundus.editor.ui.modules.inspector.components
+
+import com.mbrlabs.mundus.commons.scene3d.GameObject
+import com.mbrlabs.mundus.editor.ui.modules.inspector.BaseInspectorWidget
+
+class CustomPropertiesWidget : BaseInspectorWidget("Custom Properties") {
+
+    init {
+        isDeletable = false
+    }
+    override fun onDelete() {
+        // The custom properties component can't be deleted.
+    }
+
+    override fun setValues(go: GameObject) {
+        // TODO
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2023. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mbrlabs.mundus.editor.ui.modules.inspector.components
 
 import com.badlogic.gdx.scenes.scene2d.Actor

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -8,6 +8,7 @@
 - Fix isOnTerrain, getNormalAtWordCoordinate and getHeightAtWorldCoord methods for rotated and scaled terrain
 - Fix frustum culling not handling rotations
 - Fix water reflections when camera is rotated
+- Added custom properties option to game objects
 
 [0.4.0] ~ 10/12/2022
 - [BREAKING CHANGE] The loadScene method for the runtime has changed. A ModelBatch is no longer required to be passed in.

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/GameObjectConverter.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/GameObjectConverter.java
@@ -18,6 +18,7 @@ package com.mbrlabs.mundus.runtime.converter;
 
 import com.mbrlabs.mundus.commons.assets.AssetManager;
 import com.mbrlabs.mundus.commons.dto.GameObjectDTO;
+import com.mbrlabs.mundus.commons.mapper.CustomPropertiesComponentConverter;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
 import com.mbrlabs.mundus.runtime.Shaders;
@@ -58,6 +59,10 @@ public class GameObjectConverter {
 
         if (dto.getLightComponent() != null) {
             go.getComponents().add(LightComponentConverter.convert(dto.getLightComponent(), go));
+        }
+
+        if (dto.getCustomPropertiesComponent() != null) {
+            go.getComponents().add(CustomPropertiesComponentConverter.convert(dto.getCustomPropertiesComponent(), go));
         }
 
         // recursively convert children


### PR DESCRIPTION
Implementation of [#150](https://github.com/JamesTKhan/Mundus/issues/150) feature request.

### Usage in editor:

1) Click to the **Add component** button on a game object in inspector:
![image](https://user-images.githubusercontent.com/1684274/236186285-24dacb57-704d-4b5f-bcbf-2bf507a0b621.png)

2) Select **CUSTOM PROPERTIES** item in the dropdown and click to the **Add component** button:
![image](https://user-images.githubusercontent.com/1684274/236186532-5963f4df-85b1-4acb-9ffb-e5ca98ff9298.png)

3) See the new custom properties component in inspector:
![image](https://user-images.githubusercontent.com/1684274/236186896-ddf5ea08-94e6-4a05-8d20-1a6d82303f4b.png)

    You can remove added custom properties component with the **X** button on the left side. And you can collapse this widget with **ˇ** button on the right side.

4) Can add new custom property key-value pair with **Add** button. It will create an empty key-value pair and can change their texts. 
![image](https://user-images.githubusercontent.com/1684274/236187845-f7ac0f1c-cbc4-44c4-a36a-265a62b4f8a3.png)

5) There is only one restriction: can not be 2 keys with same text. In this case if the user click out from the key field the key's value change back to the previous valid value.
![image](https://user-images.githubusercontent.com/1684274/236188497-bf6af5e2-fd98-4efd-80ff-a6c7b7a063b9.png)

### Usage in runtime:

```java
GameObject go = getYourGameObject();
CustomPropertiesComponent component = (CustomPropertiesComponent) go.findComponentByType(Component.Type.CUSTOM_PROPERTIES);
String hp = component.get("hp");
Gdx.app.log("", "HP: " + hp);
```



This is not braking change, you can use in any project without data lost.