### PR TITLE
Update Terrain Normal blending

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.uber.frag.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.uber.frag.glsl
@@ -125,25 +125,31 @@ void main(void) {
         #endif
 
         #ifdef normalTextureFlag
+            vec3 splatNormal = vec3(0.0);
             // Splat normals
             #ifdef splatRNormalFlag
-                normal = mix(normal, unpackNormal(texture2D(u_texture_r_normal, v_texCoord0).rgb), splat.r);
+                splatNormal += unpackNormal(texture2D(u_texture_r_normal, v_texCoord0).rgb) * splat.r;
             #endif
             #ifdef splatGNormalFlag
-                normal = mix(normal, unpackNormal(texture2D(u_texture_g_normal, v_texCoord0).rgb), splat.g);
+                splatNormal += unpackNormal(texture2D(u_texture_g_normal, v_texCoord0).rgb) * splat.g;
             #endif
             #ifdef splatBNormalFlag
-                normal = mix(normal, unpackNormal(texture2D(u_texture_b_normal, v_texCoord0).rgb), splat.b);
+                splatNormal += unpackNormal(texture2D(u_texture_b_normal, v_texCoord0).rgb) * splat.b;
             #endif
             #ifdef splatANormalFlag
-                normal = mix(normal, unpackNormal(texture2D(u_texture_a_normal, v_texCoord0).rgb), splat.a);
+                splatNormal += unpackNormal(texture2D(u_texture_a_normal, v_texCoord0).rgb) * splat.a;
             #endif
+
+            // The base normal should only be visible when the sum of the splat weights is less than 1.0
+            float normalBlendFactor = (1.0 - splat.r - splat.g - splat.b - splat.a);
+            normal = normalize((normal * normalBlendFactor) + splatNormal);
 
         #endif
 
     #endif
 
     #ifdef normalTextureFlag
+        // Apply TBN matrix to tangent space normal to get world space normal
         normal = normalize(v_TBN * normal);
     #else
         normal = normalize(v_TBN[2].xyz);

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.uber.frag.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.uber.frag.glsl
@@ -91,6 +91,11 @@ varying mat3 v_TBN;
 varying MED vec2 v_texCoord0;
 varying float v_clipDistance;
 
+vec3 unpackNormal(vec3 normal)
+{
+    return normalize(normal * 2.0 - 1.0);
+}
+
 void main(void) {
     if ( v_clipDistance < 0.0 )
         discard;
@@ -100,7 +105,7 @@ void main(void) {
     gl_FragColor = texture2D(u_baseTexture, v_texCoord0);
 
     #ifdef baseNormalFlag
-        normal = texture2D(u_texture_base_normal, v_texCoord0).rgb;
+        normal = unpackNormal(texture2D(u_texture_base_normal, v_texCoord0).rgb);
     #endif
 
     // Mix splat textures
@@ -122,16 +127,16 @@ void main(void) {
         #ifdef normalTextureFlag
             // Splat normals
             #ifdef splatRNormalFlag
-                normal = mix(normal, texture2D(u_texture_r_normal, v_texCoord0).rgb, splat.r);
+                normal = mix(normal, unpackNormal(texture2D(u_texture_r_normal, v_texCoord0).rgb), splat.r);
             #endif
             #ifdef splatGNormalFlag
-                normal = mix(normal, texture2D(u_texture_g_normal, v_texCoord0).rgb, splat.g);
+                normal = mix(normal, unpackNormal(texture2D(u_texture_g_normal, v_texCoord0).rgb), splat.g);
             #endif
             #ifdef splatBNormalFlag
-                normal = mix(normal, texture2D(u_texture_b_normal, v_texCoord0).rgb, splat.b);
+                normal = mix(normal, unpackNormal(texture2D(u_texture_b_normal, v_texCoord0).rgb), splat.b);
             #endif
             #ifdef splatANormalFlag
-                normal = mix(normal, texture2D(u_texture_a_normal, v_texCoord0).rgb, splat.a);
+                normal = mix(normal, unpackNormal(texture2D(u_texture_a_normal, v_texCoord0).rgb), splat.a);
             #endif
 
         #endif
@@ -139,7 +144,7 @@ void main(void) {
     #endif
 
     #ifdef normalTextureFlag
-        normal = normalize(v_TBN * ((2.0 * normal - 1.0)));
+        normal = normalize(v_TBN * normal);
     #else
         normal = normalize(v_TBN[2].xyz);
     #endif

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.uber.frag.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.uber.frag.glsl
@@ -91,6 +91,7 @@ varying mat3 v_TBN;
 varying MED vec2 v_texCoord0;
 varying float v_clipDistance;
 
+// Brings the normal from [0, 1] to [-1, 1]
 vec3 unpackNormal(vec3 normal)
 {
     return normalize(normal * 2.0 - 1.0);
@@ -143,7 +144,6 @@ void main(void) {
             // The base normal should only be visible when the sum of the splat weights is less than 1.0
             float normalBlendFactor = (1.0 - splat.r - splat.g - splat.b - splat.a);
             normal = normalize((normal * normalBlendFactor) + splatNormal);
-
         #endif
 
     #endif


### PR DESCRIPTION
While working on triplanar mapping I made some other changes to how normals for splat maps get blended. This shouldn't result in a visual change. Putting this PR in first to try and keep things cleaner.