### PR TITLE
Gizmo fix

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -16,6 +16,7 @@
 - Fix selection after model delete
 - Fix temporary files not deleted on model import
 - Fix reset import model dialog on close
+- Fix Gizmos not adding and removing on Project/Scene changes
 - Change scene camera to be base camera class
 - Duplicate materials from inspector
 - Show brush selection

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/EditorScene.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/EditorScene.java
@@ -51,6 +51,9 @@ public class EditorScene extends Scene {
         fboDepthRefraction = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
     }
 
+    /**
+     * Call this when the scene is loaded and is now the current active scene.
+     */
     public void onLoaded() {
         // Post component added events for all components in the scene now that it is loaded
         for (GameObject gameObject : sceneGraph.getGameObjects()) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/EditorScene.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/EditorScene.java
@@ -21,8 +21,11 @@ import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.viewport.Viewport;
 import com.mbrlabs.mundus.commons.Scene;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
+import com.mbrlabs.mundus.commons.scene3d.components.Component;
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent;
 import com.mbrlabs.mundus.commons.utils.NestableFrameBuffer;
+import com.mbrlabs.mundus.editor.Mundus;
+import com.mbrlabs.mundus.editor.events.ComponentAddedEvent;
 
 /**
  * @author Marcus Brummer
@@ -46,5 +49,14 @@ public class EditorScene extends Scene {
         fboWaterReflection = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
         fboWaterRefraction = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
         fboDepthRefraction = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
+    }
+
+    public void onLoaded() {
+        // Post component added events for all components in the scene now that it is loaded
+        for (GameObject gameObject : sceneGraph.getGameObjects()) {
+            for (Component component : gameObject.getComponents()) {
+                Mundus.INSTANCE.postEvent(new ComponentAddedEvent(component));
+            }
+        }
     }
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/converter/GameObjectConverter.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/converter/GameObjectConverter.java
@@ -24,8 +24,6 @@ import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
 import com.mbrlabs.mundus.commons.scene3d.components.Component;
 import com.mbrlabs.mundus.commons.scene3d.components.LightComponent;
-import com.mbrlabs.mundus.editor.Mundus;
-import com.mbrlabs.mundus.editor.events.ComponentAddedEvent;
 import com.mbrlabs.mundus.editor.scene3d.components.PickableModelComponent;
 import com.mbrlabs.mundus.editor.scene3d.components.PickableTerrainComponent;
 import com.mbrlabs.mundus.editor.scene3d.components.PickableWaterComponent;
@@ -74,7 +72,6 @@ public class GameObjectConverter {
         if (dto.getLightComponent() != null) {
             LightComponent component = PickableLightComponentConverter.convert(dto.getLightComponent(), go);
             go.getComponents().add(component);
-            Mundus.INSTANCE.postEvent(new ComponentAddedEvent(component));
         }
 
         // recursively convert children

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -409,6 +409,7 @@ public class ProjectManager implements Disposable {
 
         Gdx.graphics.setTitle(constructWindowTitle());
         Mundus.INSTANCE.postEvent(new ProjectChangedEvent(context));
+        currentProject.currScene.onLoaded();
     }
 
     /**
@@ -518,6 +519,7 @@ public class ProjectManager implements Disposable {
 
             Gdx.graphics.setTitle(constructWindowTitle());
             Mundus.INSTANCE.postEvent(new SceneChangedEvent());
+            projectContext.currScene.onLoaded();
         } catch (FileNotFoundException e) {
             e.printStackTrace();
             Log.error(TAG, e.getMessage());

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/gizmos/GizmoManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/gizmos/GizmoManager.kt
@@ -9,6 +9,7 @@ import com.mbrlabs.mundus.commons.scene3d.components.LightComponent
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.events.ComponentAddedEvent
 import com.mbrlabs.mundus.editor.events.ComponentRemovedEvent
+import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
 import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.events.SceneGraphChangedEvent
 
@@ -21,7 +22,10 @@ import com.mbrlabs.mundus.editor.events.SceneGraphChangedEvent
 class GizmoManager : ComponentAddedEvent.ComponentAddedListener,
         ComponentRemovedEvent.ComponentRemovedListener,
         SceneGraphChangedEvent.SceneGraphChangedListener,
-        SceneChangedEvent.SceneChangedListener {
+        SceneChangedEvent.SceneChangedListener,
+        ProjectChangedEvent.ProjectChangedListener {
+
+
     private lateinit var camera: Camera
     private lateinit var decalBatch: DecalBatch
 
@@ -85,6 +89,14 @@ class GizmoManager : ComponentAddedEvent.ComponentAddedListener,
     }
 
     override fun onSceneChanged(event: SceneChangedEvent) {
+        clearGizmos()
+    }
+
+    override fun onProjectChanged(event: ProjectChangedEvent) {
+        clearGizmos()
+    }
+
+    private fun clearGizmos() {
         for (gizmo in gizmos) {
             gizmo.dispose()
         }


### PR DESCRIPTION
Gizmos were not being added/removed correctly on scene and project changes due to tricky timing of events. This change makes it so that the ComponentAdded event is not called until AFTER ProjectChanged and SceneChanged events are called. This makes more sense flow wise and allows gizmo manager to dispose of old gizmos first before receiving new ones.