### PR TITLE
Fix helper line if added terrain when helper lines is disabled

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HelperLines.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HelperLines.kt
@@ -31,7 +31,7 @@ class HelperLines : TerrainVerticesChangedEvent.TerrainVerticesChangedEventListe
 
     private val helperLineShapes = Array<HelperLineShape>()
     private var width = -1
-    private var type = HelperLineType.RECTANGLE
+    private var type: HelperLineType? = null
 
 
     fun build(type: HelperLineType, width: Int, terrainComponents: Array<TerrainComponent>) {
@@ -56,7 +56,9 @@ class HelperLines : TerrainVerticesChangedEvent.TerrainVerticesChangedEventListe
     }
 
     override fun onTerrainAdded(event: TerrainAddedEvent) {
-        addNewHelperLineShape(event.terrainComponent)
+        if (type != null) {
+            addNewHelperLineShape(event.terrainComponent)
+        }
     }
 
     override fun onTerrainRemoved(event: TerrainRemovedEvent) {
@@ -69,6 +71,7 @@ class HelperLines : TerrainVerticesChangedEvent.TerrainVerticesChangedEventListe
     override fun dispose() {
         helperLineShapes.forEach { helperLineObject -> helperLineObject.dispose() }
         helperLineShapes.clear()
+        type = null
     }
 
     private fun addNewHelperLineShape(terrainComponent: TerrainComponent) {


### PR DESCRIPTION
A small fix for helper lines. Currently helper line function doesn't check helper lines status (enabled/disabled) when a terrain added and tries to add helper line object.

How to reproduce this bug:
1) Check that the helper lines function is disabled
2) Add a new terrain
3) See error in console