### PR TITLE
Component text instead of enum value on component dialog

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddComponentDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddComponentDialog.kt
@@ -22,8 +22,15 @@ import com.mbrlabs.mundus.editor.ui.UI
 
 class AddComponentDialog : BaseDialog("Add Component") {
 
+    private enum class ComponentType(val type: Component.Type, val label: String) {
+        LIGHT(Component.Type.LIGHT, "Light"),
+        CUSTOM_PROPERTIES(Component.Type.CUSTOM_PROPERTIES, "Custom properties");
+
+        override fun toString(): String = label
+    }
+
     private lateinit var root: VisTable
-    private lateinit var selectBox: VisSelectBox<Component.Type>
+    private lateinit var selectBox: VisSelectBox<ComponentType>
     private var addBtn = VisTextButton("Add Component")
 
     private val projectManager: ProjectManager = Mundus.inject()
@@ -40,18 +47,18 @@ class AddComponentDialog : BaseDialog("Add Component") {
         // Component selector
         val selectorsTable = VisTable(true)
         selectorsTable.add(VisLabel("Component Type:"))
-        selectBox = VisSelectBox<Component.Type>()
+        selectBox = VisSelectBox<ComponentType>()
         selectorsTable.add(selectBox).left()
         root.add(selectorsTable).row()
 
         root.add(addBtn).left().growX()
 
         // Load types into select box
-        val addableTypes = Array<Component.Type>()
+        val addableTypes = Array<ComponentType>()
 
         // At the moment, only light and custom properties components are supported for dynamically adding
-        addableTypes.add(Component.Type.LIGHT)
-        addableTypes.add(Component.Type.CUSTOM_PROPERTIES)
+        addableTypes.add(ComponentType.LIGHT)
+        addableTypes.add(ComponentType.CUSTOM_PROPERTIES)
 
         selectBox.items = addableTypes
 
@@ -64,7 +71,7 @@ class AddComponentDialog : BaseDialog("Add Component") {
                 // Add component to current game object
                 val go = UI.outline.getSelectedGameObject()!!
 
-                val component = getNewComponent(selectBox.selected, go)
+                val component = getNewComponent(selectBox.selected.type, go)
                 if (component != null) {
                     try {
                         go.addComponent(component)


### PR DESCRIPTION
I think component name text is better then enum value in dropdown.

![image](https://github.com/JamesTKhan/Mundus/assets/1684274/37167f40-419c-4ca9-a336-a695fc00ad75)

What do you think?