### PR TITLE
Clear selection if selected game object deleted

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/OutlineRightClickMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/OutlineRightClickMenu.kt
@@ -11,7 +11,6 @@ import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.commons.scene3d.components.Component
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
 import com.mbrlabs.mundus.editor.Mundus
-import com.mbrlabs.mundus.editor.core.kryo.KryoManager
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.SceneGraphChangedEvent
 import com.mbrlabs.mundus.editor.events.TerrainRemovedEvent
@@ -33,7 +32,6 @@ class OutlineRightClickMenu(outline: Outline) : PopupMenu() {
 
     private val outline: Outline
     private val projectManager: ProjectManager = Mundus.inject()
-    private val kryoManager: KryoManager = Mundus.inject()
     private val toolManager: ToolManager = Mundus.inject()
 
     init {
@@ -83,7 +81,7 @@ class OutlineRightClickMenu(outline: Outline) : PopupMenu() {
                 if (selectedGO != null) {
                     outline.removeGo(selectedGO!!)
                     if (toolManager.isSelected(selectedGO!!)) {
-                        toolManager.activeTool!!.onDisabled()
+                        toolManager.setDefaultTool()
                     }
 
                     val terrainComponent = selectedGO!!.findComponentByType(Component.Type.TERRAIN) as TerrainComponent?


### PR DESCRIPTION
Currently if deleting the selected game object then the Inspector doesn't clear itself.

Before fix:
![before](https://github.com/JamesTKhan/Mundus/assets/1684274/d66f1b03-56f7-4ed6-9293-61fd9225ef13)

After fix:
![after](https://github.com/JamesTKhan/Mundus/assets/1684274/704f9944-2b4e-47b8-9dd9-7a893b45bffb)
