### PR TITLE
Max height for heightmap

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/generation/HeightmapTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/generation/HeightmapTab.kt
@@ -34,9 +34,17 @@ class HeightmapTab(private val terrainComponent: TerrainComponent) : Tab(false, 
     private val projectManager: ProjectManager = Mundus.inject()
 
     init {
+        loadHeightMapMaxHeight.text = "100"
+
         root.align(Align.left)
-        root.add(VisLabel("Range is from 0 to maximum height")).right().row()
+        root.add(VisLabel("Generate terrain using a heightmap image.\n\n" +
+                "Terrain height range is from 0 to the maximum height.\n" +
+                "Maximum height must be a positive value.\n" +
+                "Maximum height must be greater than 0.\n")).pad(5f).left().fillX().row()
         root.add(loadHeightMapMaxHeight).pad(5f).left().fillX().expandX().row()
+
+        root.add(VisLabel("\n\nSelect heightmap image:")).pad(5f).left().fillX().row()
+
         root.add(hmInput).pad(5f).left().expandX().fillX().row()
         root.add(loadHeightMapBtn).pad(5f).right().row()
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/generation/HeightmapTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/generation/HeightmapTab.kt
@@ -27,7 +27,7 @@ class HeightmapTab(private val terrainComponent: TerrainComponent) : Tab(false, 
 
     private val hmInput = FileChooserField()
     private val loadHeightMapBtn = VisTextButton("Load heightmap")
-    private val loadHeightMapMaxHeight = FloatFieldWithLabel("Min/Max height", -1, true)
+    private val loadHeightMapMinMaxHeight = FloatFieldWithLabel("Min/Max height", -1, true)
 
     private val history: CommandHistory = Mundus.inject()
     private val projectManager: ProjectManager = Mundus.inject()
@@ -35,7 +35,7 @@ class HeightmapTab(private val terrainComponent: TerrainComponent) : Tab(false, 
     init {
         root.align(Align.left)
 
-        root.add(loadHeightMapMaxHeight).pad(5f).left().fillX().expandX().row()
+        root.add(loadHeightMapMinMaxHeight).pad(5f).left().fillX().expandX().row()
         root.add(hmInput).pad(5f).left().expandX().fillX().row()
         root.add(loadHeightMapBtn).pad(5f).right().row()
 
@@ -50,9 +50,9 @@ class HeightmapTab(private val terrainComponent: TerrainComponent) : Tab(false, 
         loadHeightMapBtn.addListener(object : ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 val hm = hmInput.file
-                val max = loadHeightMapMaxHeight.float
+                val max = loadHeightMapMinMaxHeight.float
 
-                if (max == 0f) loadHeightMapMaxHeight.text = "100" // if minMax left blank or zero, set to 100
+                if (max == 0f) loadHeightMapMinMaxHeight.text = "100" // if minMax left blank or zero, set to 100
 
                 if (hm != null && hm.exists() && isImage(hm)) {
                     loadHeightMap(hm)
@@ -70,7 +70,7 @@ class HeightmapTab(private val terrainComponent: TerrainComponent) : Tab(false, 
         command.setHeightDataBefore(terrain.heightData)
 
         // Note: if user sets to negative, then height map is inverted
-        val minMax = loadHeightMapMaxHeight.float
+        val minMax = loadHeightMapMinMaxHeight.float
 
         val originalMap = Pixmap(heightMap)
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/generation/HeightmapTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/generation/HeightmapTab.kt
@@ -52,7 +52,7 @@ class HeightmapTab(private val terrainComponent: TerrainComponent) : Tab(false, 
                 val hm = hmInput.file
                 val max = loadHeightMapMaxHeight.float
 
-                if (max == 0f) loadHeightMapMaxHeight.text = "100" // if min/max left blank, set to 100
+                if (max == 0f) loadHeightMapMaxHeight.text = "100" // if minMax left blank or zero, set to 100
 
                 if (hm != null && hm.exists() && isImage(hm)) {
                     loadHeightMap(hm)
@@ -69,6 +69,7 @@ class HeightmapTab(private val terrainComponent: TerrainComponent) : Tab(false, 
         val command = TerrainHeightCommand(terrain)
         command.setHeightDataBefore(terrain.heightData)
 
+        // Note: if user sets to negative, then height map is inverted
         val minMax = loadHeightMapMaxHeight.float
 
         val originalMap = Pixmap(heightMap)

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/generation/HeightmapTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/generation/HeightmapTab.kt
@@ -33,14 +33,20 @@ class HeightmapTab(private val terrainComponent: TerrainComponent) : Tab(false, 
     private val history: CommandHistory = Mundus.inject()
     private val projectManager: ProjectManager = Mundus.inject()
 
+    private val description = """
+            Generate terrain using a heightmap image.
+            
+            Terrain height range is from 0 to the maximum height.
+            Maximum height must be a positive value.
+            Maximum height must be greater than 0.
+            
+        """.trimIndent()
+
     init {
         loadHeightMapMaxHeight.text = "100"
 
         root.align(Align.left)
-        root.add(VisLabel("Generate terrain using a heightmap image.\n\n" +
-                "Terrain height range is from 0 to the maximum height.\n" +
-                "Maximum height must be a positive value.\n" +
-                "Maximum height must be greater than 0.\n")).pad(5f).left().fillX().row()
+        root.add(VisLabel(description)).pad(5f).left().fillX().row()
         root.add(loadHeightMapMaxHeight).pad(5f).left().fillX().expandX().row()
 
         root.add(VisLabel("\n\nSelect heightmap image:")).pad(5f).left().fillX().row()

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/generation/HeightmapTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/generation/HeightmapTab.kt
@@ -7,6 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
 import com.badlogic.gdx.utils.Align
 import com.kotcrab.vis.ui.util.dialog.Dialogs
+import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
 import com.kotcrab.vis.ui.widget.tabbedpane.Tab
@@ -27,15 +28,15 @@ class HeightmapTab(private val terrainComponent: TerrainComponent) : Tab(false, 
 
     private val hmInput = FileChooserField()
     private val loadHeightMapBtn = VisTextButton("Load heightmap")
-    private val loadHeightMapMinMaxHeight = FloatFieldWithLabel("Min/Max height", -1, true)
+    private val loadHeightMapMaxHeight = FloatFieldWithLabel("Maximum height:", -1, true)
 
     private val history: CommandHistory = Mundus.inject()
     private val projectManager: ProjectManager = Mundus.inject()
 
     init {
         root.align(Align.left)
-
-        root.add(loadHeightMapMinMaxHeight).pad(5f).left().fillX().expandX().row()
+        root.add(VisLabel("Range is from 0 to maximum height")).right().row()
+        root.add(loadHeightMapMaxHeight).pad(5f).left().fillX().expandX().row()
         root.add(hmInput).pad(5f).left().expandX().fillX().row()
         root.add(loadHeightMapBtn).pad(5f).right().row()
 
@@ -50,9 +51,10 @@ class HeightmapTab(private val terrainComponent: TerrainComponent) : Tab(false, 
         loadHeightMapBtn.addListener(object : ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 val hm = hmInput.file
-                val max = loadHeightMapMinMaxHeight.float
+                val max = loadHeightMapMaxHeight.float
 
-                if (max == 0f) loadHeightMapMinMaxHeight.text = "100" // if minMax left blank or zero, set to 100
+                if (max == 0f) loadHeightMapMaxHeight.text = "100" // if max height left blank or zero, set to 100
+                if (max < 0f) loadHeightMapMaxHeight.text = "" + -max // if max is negative, then set to max to positive value
 
                 if (hm != null && hm.exists() && isImage(hm)) {
                     loadHeightMap(hm)
@@ -69,9 +71,7 @@ class HeightmapTab(private val terrainComponent: TerrainComponent) : Tab(false, 
         val command = TerrainHeightCommand(terrain)
         command.setHeightDataBefore(terrain.heightData)
 
-        // Note: if user sets to negative, then height map is inverted
-        val minMax = loadHeightMapMinMaxHeight.float
-
+        val minMax = loadHeightMapMaxHeight.float
         val originalMap = Pixmap(heightMap)
 
         // scale pixmap if it doesn't fit the terrainAsset


### PR DESCRIPTION
Added a `minMax` field to `HeightMapTab.kt`

If left blank, or set to zero (which would generate a flat terrain) then a default value positive 100 is set.
If user sets the minMax value to negative then the heightmap is inverted.

I think the `Terraformer` class does not allow negative `minHeight` so that is why I only implemented one min/max field.

See https://github.com/JamesTKhan/Mundus/issues/174#issuecomment-1567232389 for more info and screenshots.