### PR TITLE
Fix for transparent layer in texture splatting for the terrain texture #183

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.uber.frag.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.uber.frag.glsl
@@ -110,17 +110,21 @@ void main(void) {
     #ifdef splatFlag
     vec4 splat = texture2D(u_texture_splat, v_splatPosition);
         #ifdef splatRFlag
-            gl_FragColor = mix(gl_FragColor, texture2D(u_texture_r, v_texCoord0), splat.r);
+            vec4 colorR = texture2D(u_texture_r, v_texCoord0);
+            gl_FragColor = mix(gl_FragColor, mix(gl_FragColor, colorR, splat.r), colorR.a);
         #endif
         #ifdef splatGFlag
-            gl_FragColor = mix(gl_FragColor, texture2D(u_texture_g, v_texCoord0), splat.g);
+            vec4 colorG = texture2D(u_texture_g, v_texCoord0);
+            gl_FragColor = mix(gl_FragColor, mix(gl_FragColor, colorG, splat.g), colorG.a);
         #endif
         #ifdef splatBFlag
-            gl_FragColor = mix(gl_FragColor, texture2D(u_texture_b, v_texCoord0), splat.b);
-        #endif
+            vec4 colorB = texture2D(u_texture_b, v_texCoord0);
+            gl_FragColor = mix(gl_FragColor, mix(gl_FragColor, colorB, splat.b), colorB.a);
+    #endif
         #ifdef splatAFlag
-            gl_FragColor = mix(gl_FragColor, texture2D(u_texture_a, v_texCoord0), splat.a);
-        #endif
+            vec4 colorA = texture2D(u_texture_a, v_texCoord0);
+            gl_FragColor = mix(gl_FragColor, mix(gl_FragColor, colorA, splat.a), colorA.a);
+    #endif
 
         #ifdef normalTextureFlag
             vec3 splatNormal = vec3(0.0);

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -28,6 +28,7 @@
 - Fix terrain brush tools for rotated and scaled terrain
 - Refactor tool selection
 - Custom properties component addable to game objects
+- Fix transparent layer in texture splatting for the terrain texture
 
 [0.4.2] ~ 10/24/2022
 - Fix shader compilation error for Terrain when using normal maps

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -10,6 +10,7 @@
 - Fix water reflections when camera is rotated
 - Removed selected field from SceneGraph class
 - Added custom properties option to game objects
+- Fix transparent layer in texture splatting for the terrain texture
 
 [0.4.0] ~ 10/12/2022
 - [BREAKING CHANGE] The loadScene method for the runtime has changed. A ModelBatch is no longer required to be passed in.


### PR DESCRIPTION
Seems I could fix #183 . 

Before:
![image](https://github.com/JamesTKhan/Mundus/assets/1684274/ed65542d-2c76-4ddc-844f-d0b95580f7b2)

After:
![image](https://github.com/JamesTKhan/Mundus/assets/1684274/5dc7869c-6d1e-45f9-8a81-ca20c72190ac)
