### PR TITLE
GL30: Use MRT FBO for Water refractions on gl30

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/core/EditorScene.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/EditorScene.java
@@ -16,16 +16,12 @@
 
 package com.mbrlabs.mundus.editor.core;
 
-import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.graphics.GL30;
-import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.viewport.Viewport;
 import com.mbrlabs.mundus.commons.Scene;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.components.Component;
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent;
-import com.mbrlabs.mundus.commons.utils.NestableFrameBuffer;
 import com.mbrlabs.mundus.editor.Mundus;
 import com.mbrlabs.mundus.editor.events.ComponentAddedEvent;
 
@@ -44,20 +40,6 @@ public class EditorScene extends Scene {
         currentSelection = null;
         terrains = new Array<>();
         isRuntime = false;
-    }
-
-    @Override
-    protected void initFrameBuffers(int width, int height) {
-        fboWaterReflection = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
-        if (Gdx.gl30 == null) {
-            fboWaterRefraction = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
-            fboDepthRefraction = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
-        } else {
-            NestableFrameBuffer.NestableFrameBufferBuilder frameBufferBuilder = new NestableFrameBuffer.NestableFrameBufferBuilder(width, height);
-            frameBufferBuilder.addBasicColorTextureAttachment(Pixmap.Format.RGB888);
-            frameBufferBuilder.addDepthTextureAttachment(GL30.GL_DEPTH_COMPONENT24, GL30.GL_UNSIGNED_SHORT);
-            fboWaterRefraction = frameBufferBuilder.build();
-        }
     }
 
     /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/EditorScene.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/EditorScene.java
@@ -16,6 +16,8 @@
 
 package com.mbrlabs.mundus.editor.core;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.viewport.Viewport;
@@ -47,8 +49,15 @@ public class EditorScene extends Scene {
     @Override
     protected void initFrameBuffers(int width, int height) {
         fboWaterReflection = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
-        fboWaterRefraction = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
-        fboDepthRefraction = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
+        if (Gdx.gl30 == null) {
+            fboWaterRefraction = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
+            fboDepthRefraction = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
+        } else {
+            NestableFrameBuffer.NestableFrameBufferBuilder frameBufferBuilder = new NestableFrameBuffer.NestableFrameBufferBuilder(width, height);
+            frameBufferBuilder.addBasicColorTextureAttachment(Pixmap.Format.RGB888);
+            frameBufferBuilder.addDepthTextureAttachment(GL30.GL_DEPTH_COMPONENT24, GL30.GL_UNSIGNED_SHORT);
+            fboWaterRefraction = frameBufferBuilder.build();
+        }
     }
 
     /**

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -11,6 +11,7 @@
 - Removed selected field from SceneGraph class
 - Added custom properties option to game objects
 - Fix transparent layer in texture splatting for the terrain texture
+- Scene class now uses NestableFrameBuffer for water FBOs
 
 [0.4.0] ~ 10/12/2022
 - [BREAKING CHANGE] The loadScene method for the runtime has changed. A ModelBatch is no longer required to be passed in.


### PR DESCRIPTION
This is the first GL30 addition to Mundus. If GL30 is enabled/available, water refraction FBO uses MRT to attach a depth texture. This removes the need for an additional depth render pass for water refractions meaning less vertices, draw calls, and shader switches per frame. 

GL20 behavior remains the same.