### PR TITLE
Fix EventBus Performance issues

### DIFF
--- a/editor/src/test/java/com/mbrlabs/mundus/editor/events/EventBusTest.java
+++ b/editor/src/test/java/com/mbrlabs/mundus/editor/events/EventBusTest.java
@@ -1,0 +1,72 @@
+package com.mbrlabs.mundus.editor.events;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author JamesTKhan
+ * @version June 27, 2023
+ */
+public class EventBusTest {
+
+    @Test
+    public void eventsReceivedTest() {
+        EventBus eventBus = new EventBus();
+        final int[] sceneChangedEventsReceived = {0};
+        final int[] sceneAddedEventsReceived = {0};
+
+        eventBus.register(new Object() {
+            @Subscribe
+            public void onEvent(SceneChangedEvent event) {
+                sceneChangedEventsReceived[0]++;
+            }
+        });
+
+        eventBus.register(new Object() {
+            @Subscribe
+            public void onEvent(SceneAddedEvent event) {
+                sceneAddedEventsReceived[0]++;
+            }
+        });
+
+        int sceneChangedCount = 10;
+        int sceneAddedCount = 5;
+
+        for (int i = 0; i < sceneChangedCount; i++) {
+            eventBus.post(new SceneChangedEvent());
+        }
+
+        for (int i = 0; i < sceneAddedCount; i++) {
+            eventBus.post(new SceneAddedEvent(null));
+        }
+
+        // check if events were received
+        Assert.assertEquals(sceneChangedEventsReceived[0], sceneChangedCount);
+        Assert.assertEquals(sceneAddedEventsReceived[0], sceneAddedCount);
+    }
+
+    @Test
+    public void unregisterTest() {
+        EventBus eventBus = new EventBus();
+        final int[] sceneChangedEventsReceived = {0};
+
+        Object subscriber = new Object() {
+            @Subscribe
+            public void onEvent(SceneChangedEvent event) {
+                sceneChangedEventsReceived[0]++;
+            }
+        };
+
+        // register and post, should receive 1 event
+        eventBus.register(subscriber);
+        eventBus.post(new SceneChangedEvent());
+
+        // unregister and post, should not receive any events
+        eventBus.unregister(subscriber);
+        eventBus.post(new SceneChangedEvent());
+
+        // should still be 1
+        Assert.assertEquals(sceneChangedEventsReceived[0], 1);
+    }
+
+}


### PR DESCRIPTION
While working on a feature branch, I noticed a frame drop when posting evens often. I looked into the EventBus code for the first time and saw some areas for improvement. Every time an event was posted the EventBus searched through every subscriber, check that it is a subscriber, and then find and call the event method all of this using reflection was quite slow.

Updated the EventBus class to perform the reflection logic on Register instead, and then cache Event class -> Subscriber in a map for fast lookup on Post so now we only perform the slow operations once on register. Also cleaned up the class a bit and added more code documentation to the methods.

Additionally, added a junit test for the EventBus.

In a quick performance test of posting 100 events with 100 subscribers, the old code took 22ms, the new code took 2ms.