### PR TITLE
SimpleNode efficiency, cache transforms

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
@@ -335,18 +335,21 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
         super.setLocalScale(x, y, z);
         // We track when the scale has changed, for recalculating bounds for things like frustum culling
         scaleChanged = true;
+        updateChildrenScaleChanged(this);
     }
 
     @Override
     public void scale(Vector3 v) {
         super.scale(v);
         scaleChanged = true;
+        updateChildrenScaleChanged(this);
     }
 
     @Override
     public void scale(float x, float y, float z) {
         super.scale(x,y,z);
         scaleChanged = true;
+        updateChildrenScaleChanged(this);
     }
 
     @Override
@@ -377,6 +380,15 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
     @Override
     public String toString() {
         return name;
+    }
+
+    private void updateChildrenScaleChanged(GameObject go) {
+        if (go.getChildren() == null) return;
+        // Update all children recursively
+        for (GameObject child : go.getChildren()) {
+            child.scaleChanged = true;
+            updateChildrenScaleChanged(child);
+        }
     }
 
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SimpleNode.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SimpleNode.java
@@ -21,10 +21,7 @@ import com.badlogic.gdx.math.Quaternion;
 import com.badlogic.gdx.math.Vector3;
 
 /**
- * Very simple and incredible inefficient implementation of a scene graph node.
- *
- * Inefficient, because each call to getTransform() multiplies all parent
- * transformation matrices without caching them.
+ * Very simple implementation of a scene graph node.
  *
  * @author Marcus Brummer
  * @version 09-06-2016

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SimpleNode.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SimpleNode.java
@@ -38,7 +38,7 @@ public class SimpleNode<T extends SimpleNode> extends BaseNode<T> {
     private final Matrix4 combined;
 
     /** Flag to indicate that the transform is dirty and needs to be recalculated */
-    boolean isTransformDirty;
+    protected boolean isTransformDirty;
 
     public SimpleNode(int id) {
         super(id);

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/LightComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/LightComponent.java
@@ -53,7 +53,9 @@ public class LightComponent extends AbstractComponent {
 
     @Override
     public void update(float delta) {
-        position.set(gameObject.getPosition(tmp));
+        if (gameObject.isDirty()) {
+            position.set(gameObject.getPosition(tmp));
+        }
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
@@ -50,7 +50,9 @@ public class ModelComponent extends CullableComponent implements AssetUsage, Mod
     @Override
     public void update(float delta) {
         super.update(delta);
-        modelInstance.transform.set(gameObject.getTransform());
+        if (gameObject.isDirty()) {
+            modelInstance.transform.set(gameObject.getTransform());
+        }
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/TerrainComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/TerrainComponent.java
@@ -25,7 +25,6 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.mbrlabs.mundus.commons.assets.Asset;
 import com.mbrlabs.mundus.commons.assets.TerrainAsset;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
-import com.mbrlabs.mundus.commons.shaders.ClippableShader;
 import net.mgsx.gltf.scene3d.attributes.PBRTextureAttribute;
 
 import java.util.Objects;
@@ -44,6 +43,14 @@ public class TerrainComponent extends CullableComponent implements AssetUsage, R
     public TerrainComponent(GameObject go) {
         super(go);
         type = Component.Type.TERRAIN;
+    }
+
+    @Override
+    public void update(float delta) {
+        super.update(delta);
+        if (gameObject.isDirty()) {
+            modelInstance.transform.set(gameObject.getTransform());
+        }
     }
 
     @Override

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -1,5 +1,8 @@
 [0.5.1]
+- Add dirty transform flag optimization for caching GameObject/SimpleNode world transform
 - Fix mouse picking by not rendering inactive game objects to picker
+- Fix Child terrain objects not updating on translation
+- Refactor outline drag and drop world to local conversion code when moving game objects
 
 [0.5.0]
 - [Breaking Change] Lighting systems updated, visibly different. See PR#184

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
@@ -186,7 +186,6 @@ class Outline : VisTable(),
                         return
                     }
                 }
-                val oldParent = draggedGo.parent
 
                 // remove child from old parent
                 draggedGo.remove()
@@ -194,40 +193,42 @@ class Outline : VisTable(),
                 // add to new parent
                 if (newParent == null) {
 
-                    // if moved from old parent
-                    if (oldParent != null) {
-                        // Convert draggedGo from old parents local space to world space
-                        val world = draggedGo.transform.mulLeft(oldParent.transform)
-                        world.getTranslation(tmpPos)
-                        world.getRotation(tmpQuat, true)
-                        world.getScale(tmpScale)
+                    // Get the current world transform of the GameObject
+                    val worldPos = draggedGo.getPosition(tmpPos)
+                    val worldRot = draggedGo.getRotation(tmpQuat)
+                    val worldScale = draggedGo.getScale(tmpScale)
 
-                        // add
-                        context.currScene.sceneGraph.root.addChild(draggedGo)
-                        draggedGo.setLocalPosition(tmpPos.x, tmpPos.y, tmpPos.z)
-                        draggedGo.setLocalRotation(tmpQuat.x, tmpQuat.y, tmpQuat.z, tmpQuat.w)
-                        draggedGo.setLocalScale(tmpScale.x, tmpScale.y, tmpScale.z)
-                    } else {
-                        // Is this scenario even possible right now? Null new and old parent.
-                        val newPos = draggedGo.getPosition(tmpPos)
-                        // new local position = World position
-                        draggedGo.setLocalPosition(newPos.x, newPos.y, newPos.z)
-                    }
+                    // Set the local transform to the current world transform
+                    draggedGo.setLocalPosition(worldPos.x, worldPos.y, worldPos.z)
+                    draggedGo.setLocalRotation(worldRot.x, worldRot.y, worldRot.z, worldRot.w)
+                    draggedGo.setLocalScale(worldScale.x, worldScale.y, worldScale.z)
+
+                    context.currScene.sceneGraph.root.addChild(draggedGo)
 
                 } else {
                     val parentGo = newParent.value
 
-                    // Convert draggedGo to new parents local space
-                    val local = draggedGo.transform.mulLeft(parentGo.transform.inv())
-                    local.getTranslation(tmpPos)
-                    local.getRotation(tmpQuat, true)
-                    local.getScale(tmpScale)
+                    // Get the current world transform of the GameObject
+                    val childWorldTransform = draggedGo.transform
 
-                    // add
-                    parentGo.addChild(draggedGo)
+                    // Get the inverse world transform of the new parent
+                    val invParentWorldTransform = parentGo.transform.cpy().inv()
+
+                    // Multiply to get the new local transform
+                    val localTransform = invParentWorldTransform.mul(childWorldTransform)
+
+                    // Extract the new local position, rotation, and scale
+                    localTransform.getTranslation(tmpPos)
+                    localTransform.getRotation(tmpQuat, true)
+                    localTransform.getScale(tmpScale)
+
+                    // Set the new local transform
                     draggedGo.setLocalPosition(tmpPos.x, tmpPos.y, tmpPos.z)
                     draggedGo.setLocalRotation(tmpQuat.x, tmpQuat.y, tmpQuat.z, tmpQuat.w)
                     draggedGo.setLocalScale(tmpScale.x, tmpScale.y, tmpScale.z)
+
+                    // add
+                    parentGo.addChild(draggedGo)
                 }
 
                 // update tree

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
@@ -36,6 +36,7 @@ import com.mbrlabs.mundus.commons.scene3d.components.Component
 import com.mbrlabs.mundus.commons.scene3d.components.LightComponent
 import com.mbrlabs.mundus.commons.utils.LightUtils
 import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.Mundus.postEvent
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.*
 import com.mbrlabs.mundus.editor.history.CommandHistory
@@ -233,6 +234,7 @@ class Outline : VisTable(),
 
                 // update tree
                 buildTree(projectManager.current().currScene.sceneGraph)
+                postEvent(GameObjectModifiedEvent(draggedGo))
             }
 
         })


### PR DESCRIPTION
Several things here, primarily adding the SimpleNode enhancement for the issue that I opened a while back.

1. Add dirty transform flag to SimpleNode to improve efficiency of SimpleNode. Every time getTransform, getPosition, getRotation and getScaled are called on a GameObject, the objects world transform is recalculated and this becomes worse the more nested children you have. Now the transform is cached and only updated when flagged as dirty.

2. Fix object scale not marked as changed for children, breaking frustum culling on children with scaled parents.

3. Translating children terrains parents caused them to not update visually. That is fixed now.

4. I revamped some of the conversion code in outline for drag and drop of children as it was behaving strange and compounding the objects scale as you drag and drop it. Dragging a GO into (or out of) a parent should now preserve position/scale/rotation, before it did not and this feels more natural to me.

This changes core functionality (positioning of game objects) I have tested by opening several projects and so far everything seems normal