### PR TITLE
Add FPS launch argument

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/Main.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Main.kt
@@ -48,6 +48,9 @@ class LaunchOptions {
 
     @Option(name="-noShaderCache", usage="Disable shader preprocessor caching, useful for hot reloads during shader development")
     var noShaderCache = false
+
+    @Option(name="-fpsLimit", usage="Set FPS limit")
+    var fps = 60 // Default to 60 FPS limit (ex -fpsLimit=30)
 }
 
 fun main(arg: Array<String>) {
@@ -86,6 +89,7 @@ private fun launchEditor(options: LaunchOptions) {
     config.setWindowSizeLimits(1350, 1, 9999, 9999)
     config.setWindowPosition(-1, -1)
     config.setWindowIcon("icon/logo.png")
+    config.setForegroundFPS(options.fps)
 
     if (options.useGL30) {
         if (SharedLibraryLoader.isMac) {


### PR DESCRIPTION
Adds the option to set FPS limit via argument. Also, this ALWAYS sets the setForegroundFPS option.

By not setting this value, if you have Mundus running and let you screens go to sleep the VSYNC seems to stop working, and will thrash your GPU while your screens are off.