### PR TITLE
Undo removed light fix

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -1,5 +1,6 @@
 [0.5.1]
 - Fix mouse picking by not rendering inactive game objects to picker
+- Fix undo removed light component on selected game object
 
 [0.5.0]
 - [Breaking Change] Lighting systems updated, visibly different. See PR#184

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/GameObjectInspector.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/GameObjectInspector.kt
@@ -70,6 +70,8 @@ class GameObjectInspector : VisTable() {
         })
     }
 
+    fun getGameObject() : GameObject? = gameObject
+
     fun setGameObject(gameObject: GameObject) {
         this.gameObject = gameObject
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/Inspector.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/Inspector.kt
@@ -103,7 +103,11 @@ class Inspector : VisTable(),
     }
 
     override fun onComponentAdded(event: ComponentAddedEvent) {
-        goInspector.addComponent(event.component)
+        val component = event.component
+
+        if (component.gameObject == goInspector.getGameObject()) {
+            goInspector.addComponent(component)
+        }
     }
 
 }


### PR DESCRIPTION
If I delete a game object what contains light component and select an another game object (what doesn't contain light component) and undo deleted game object then the light component will be show on the selected game object.

Before fix:
![before_fix](https://github.com/JamesTKhan/Mundus/assets/1684274/b2772c9b-657d-4be1-a953-7f2d26f5bfed)

After fix:
![after_fix](https://github.com/JamesTKhan/Mundus/assets/1684274/6953d398-8201-4cb5-b8f8-d69ef0a0466d)
