### PR TITLE
Upgrade libGDX to 1.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
 
     ext {
         appName = "Mundus"
-        gdxVersion = '1.11.0'
+        gdxVersion = '1.12.0'
         visuiVersion = '1.5.0'
         kryoVersion = '5.2.0'
         junitVersion = '4.13.2'

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -1,10 +1,11 @@
-[0.5.1]
+[0.5.1] ~
 - Added FPS launcher argument, always call setForegroundFPS
 - Fix mouse picking by not rendering inactive game objects to picker
 - Fix removed terrain in helper lines
 - Fix undo removed light component on selected game object
+- Updated libGDX to 1.12.0
 
-[0.5.0]
+[0.5.0] ~ 06/28/2023
 - [Breaking Change] Lighting systems updated, visibly different. See PR#184
 - Convert Water Shader to an Uber Shader
 - Water Shader Enhancements (visible depth, toggle reflection/refraction)

--- a/editor/src/main/com/mbrlabs/mundus/editor/profiling/MundusGL30Interceptor.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/profiling/MundusGL30Interceptor.java
@@ -1225,6 +1225,13 @@ public class MundusGL30Interceptor extends MundusGLInterceptor implements GL30{
     }
 
     @Override
+    public void glTexImage2D(int target, int level, int internalformat, int width, int height, int border, int format, int type, int offset) {
+        incrementCalls();
+        gl30.glTexImage2D(target, level, internalformat, width, height, border, format, type, offset);
+        check();
+    }
+
+    @Override
     public void glTexImage3D (int target, int level, int internalformat, int width, int height, int depth, int border, int format,
                               int type, Buffer pixels) {
         incrementCalls();
@@ -1237,6 +1244,13 @@ public class MundusGL30Interceptor extends MundusGLInterceptor implements GL30{
                               int type, int offset) {
         incrementCalls();
         gl30.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, offset);
+        check();
+    }
+
+    @Override
+    public void glTexSubImage2D(int target, int level, int xoffset, int yoffset, int width, int height, int format, int type, int offset) {
+        incrementCalls();
+        gl30.glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, offset);
         check();
     }
 

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -1,4 +1,7 @@
-[0.5.0] ~
+[0.5.1] ~
+- Updated libGDX to 1.12.0
+
+[0.5.0] ~ 06/28/2023
 - [Breaking Change] Terrain API modified to closer reflect Models
 - [Breaking Change] ShadowMapper class removed. Replaced with MundusDirectionalShadowLight
 - Lighting systems updated, visibly different. See PR#184


### PR DESCRIPTION
Upgrade to libGDX 1.12.0. With that I also fixed an invalid value being used in GL30 MRT FBO construction. After testing many variations, one of the reasons I was looking forward to WebGL2 is currently useless. 

Using the same code for MRT FBO with 24bit Depth on WebGL2 vs Desktop, there are precision issues on WebGL2 with the water rendering. On desktop this is not happening. Unknown why at this time, so Water refractions will not use MRT FBO's on WebGL2 for the time being as it should not hold back the update to 1.12.0.