### PR TITLE
Helper lines support for terrain chunks

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HelperLineShape.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HelperLineShape.kt
@@ -86,4 +86,28 @@ abstract class HelperLineShape(width: Int, val terrainComponent: TerrainComponen
         modelInstance.model!!.dispose()
     }
 
+    protected fun calculateRightTerrainChunksVertexResolution() : Int {
+        var rightTerrainComponent = terrainComponent.rightNeighbor
+        var allVertexResolution = 0
+
+        while (rightTerrainComponent != null) {
+            allVertexResolution += rightTerrainComponent.terrainAsset.terrain.vertexResolution - 1
+            rightTerrainComponent = rightTerrainComponent.rightNeighbor
+        }
+
+        return allVertexResolution
+    }
+
+    protected fun calculateBottomTerrainChunksVertexResolution() : Int {
+        var bottomTerrainComponent = terrainComponent.bottomNeighbor
+        var allVertexResolution = 0
+
+        while (bottomTerrainComponent != null) {
+            allVertexResolution += bottomTerrainComponent.terrainAsset.terrain.vertexResolution - 1
+            bottomTerrainComponent = bottomTerrainComponent.bottomNeighbor
+        }
+
+        return allVertexResolution
+    }
+
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HelperLines.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HelperLines.kt
@@ -21,12 +21,14 @@ import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
 import com.badlogic.gdx.utils.Array
 import com.badlogic.gdx.utils.Disposable
 import com.mbrlabs.mundus.editor.events.TerrainAddedEvent
+import com.mbrlabs.mundus.editor.events.TerrainNewNeighborEvent
 import com.mbrlabs.mundus.editor.events.TerrainRemovedEvent
 import com.mbrlabs.mundus.editor.events.TerrainVerticesChangedEvent
 
 class HelperLines : TerrainVerticesChangedEvent.TerrainVerticesChangedEventListener,
         TerrainAddedEvent.TerrainAddedEventListener,
         TerrainRemovedEvent.TerrainRemovedEventListener,
+        TerrainNewNeighborEvent.TerrainNewNeighborEventListener,
         Disposable {
 
     private val helperLineShapes = Array<HelperLineShape>()
@@ -62,16 +64,26 @@ class HelperLines : TerrainVerticesChangedEvent.TerrainVerticesChangedEventListe
     }
 
     override fun onTerrainRemoved(event: TerrainRemovedEvent) {
-        helperLineShapes.filter { it.terrainComponent == event.terrainComponent }.forEach {
-            it.dispose()
-            helperLineShapes.removeValue(it, true)
-        }
+        removeHelperLine(event.terrainComponent)
+    }
+
+    override fun onNewTerrainNeighbor(event: TerrainNewNeighborEvent) {
+        val terrainComponent = event.terrainComponent
+        removeHelperLine(terrainComponent)
+        addNewHelperLineShape(terrainComponent)
     }
 
     override fun dispose() {
         helperLineShapes.forEach { helperLineObject -> helperLineObject.dispose() }
         helperLineShapes.clear()
         type = null
+    }
+
+    private fun removeHelperLine(terrainComponent: TerrainComponent) {
+        helperLineShapes.filter { it.terrainComponent == terrainComponent }.forEach {
+            it.dispose()
+            helperLineShapes.removeValue(it, true)
+        }
     }
 
     private fun addNewHelperLineShape(terrainComponent: TerrainComponent) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HexagonHelperLineShape.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HexagonHelperLineShape.kt
@@ -47,15 +47,18 @@ class HexagonHelperLineShape(width: Int, terrainComponent: TerrainComponent) : H
     }
 
     private fun calculate(width: Int, vertexResolution: Int, method: (pos: Short) -> Unit) {
+        val bottomTerrainChunksVertexResolution = calculateBottomTerrainChunksVertexResolution()
         val rightTerrainChunksVertexResolution = calculateRightTerrainChunksVertexResolution()
 
+        val yUsedWidth = bottomTerrainChunksVertexResolution % width
         val xUsedWidth = rightTerrainChunksVertexResolution % width
 
+        val yInit = if (yUsedWidth == 0) 0 else -yUsedWidth
         val xInit = if (xUsedWidth == 0) 0 else -xUsedWidth
 
-        var patternY = 0
+        var patternY = ((bottomTerrainChunksVertexResolution - yUsedWidth) / width) % PATTERN.size
 
-        for (y in 0 until vertexResolution + width step width) {
+        for (y in yInit until vertexResolution + width step width) {
             var patternX = ((rightTerrainChunksVertexResolution - xUsedWidth) / width) % PATTERN.get(patternY).size
 
             for (x in xInit until vertexResolution step width) {
@@ -66,7 +69,7 @@ class HexagonHelperLineShape(width: Int, terrainComponent: TerrainComponent) : H
                     for (w in 0 until  width) {
                         val next = getNext(current, pattern, vertexResolution)
 
-                        if (x + w >= 0) {
+                        if (current >= 0 && next >= 0 && x + w >= 0) {
                             if (isOnMap(current, vertexResolution) && isOk(current, next, vertexResolution, pattern) && isOnMap(next, vertexResolution)) {
                                 method.invoke(current.toShort())
                                 method.invoke(next.toShort())

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HexagonHelperLineShape.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HexagonHelperLineShape.kt
@@ -76,6 +76,8 @@ class HexagonHelperLineShape(width: Int, terrainComponent: TerrainComponent) : H
                             } else if (!isOk(current, next, vertexResolution, pattern)) {
                                 break
                             }
+                        } else if (current == -1 && next == 0) {
+                            break
                         }
 
                         current = next
@@ -110,5 +112,5 @@ class HexagonHelperLineShape(width: Int, terrainComponent: TerrainComponent) : H
         }
     }
 
-    private fun getRow(cell: Int, vertexResolution: Int) = cell / vertexResolution
+    private fun getRow(cell: Int, vertexResolution: Int) = cell / vertexResolution + if (cell < 0) -1 else 0
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HexagonHelperLineShape.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HexagonHelperLineShape.kt
@@ -47,11 +47,18 @@ class HexagonHelperLineShape(width: Int, terrainComponent: TerrainComponent) : H
     }
 
     private fun calculate(width: Int, vertexResolution: Int, method: (pos: Short) -> Unit) {
+        val rightTerrainChunksVertexResolution = calculateRightTerrainChunksVertexResolution()
+
+        val xUsedWidth = rightTerrainChunksVertexResolution % width
+
+        val xInit = if (xUsedWidth == 0) 0 else -xUsedWidth
+
         var patternY = 0
 
         for (y in 0 until vertexResolution + width step width) {
-            var patternX = 0
-            for (x in 0 until vertexResolution step width) {
+            var patternX = ((rightTerrainChunksVertexResolution - xUsedWidth) / width) % PATTERN.get(patternY).size
+
+            for (x in xInit until vertexResolution step width) {
                 val mainCurrent = y * vertexResolution + x
 
                 for (pattern in PATTERN.get(patternY).get(patternX)) {
@@ -59,15 +66,16 @@ class HexagonHelperLineShape(width: Int, terrainComponent: TerrainComponent) : H
                     for (w in 0 until  width) {
                         val next = getNext(current, pattern, vertexResolution)
 
-                        if (isOnMap(current, vertexResolution) && isOk(current, next, vertexResolution, pattern) && isOnMap(next, vertexResolution)) {
-                            method.invoke(current.toShort())
-                            method.invoke(next.toShort())
-                        } else if (!isOk(current, next, vertexResolution, pattern)) {
-                            break
+                        if (x + w >= 0) {
+                            if (isOnMap(current, vertexResolution) && isOk(current, next, vertexResolution, pattern) && isOnMap(next, vertexResolution)) {
+                                method.invoke(current.toShort())
+                                method.invoke(next.toShort())
+                            } else if (!isOk(current, next, vertexResolution, pattern)) {
+                                break
+                            }
                         }
 
                         current = next
-
                     }
                 }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/RectangleHelperLineShape.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/RectangleHelperLineShape.kt
@@ -23,29 +23,40 @@ class RectangleHelperLineShape(width: Int,
                                terrainComponent: TerrainComponent) : HelperLineShape(width, terrainComponent) {
 
     override fun calculateIndicesNum(width: Int, terrain: Terrain): Int {
-        val vertexResolution = terrain.vertexResolution
-
-        return vertexResolution * 2 * ((vertexResolution / width) + 1) * 2
+        var i = 0
+        calculate(width, terrain.vertexResolution) { ++i }
+        return i
     }
 
     override fun fillIndices(width: Int, indices: ShortArray, vertexResolution: Int) {
-        var i = -1
-        for (y in 0 until vertexResolution step width) {
-            for (x in 0 until  vertexResolution - 1) {
-                val current = y * vertexResolution + x
-                val next = current + 1
+        var i = 0
+        calculate(width, vertexResolution) { pos -> indices[i++] = pos }
+    }
 
-                indices[++i] = current.toShort()
-                indices[++i] = next.toShort()
+    private fun calculate(width: Int, vertexResolution: Int, method: (pos: Short) -> Unit) {
+        val yInit = 0 - (calculateBottomTerrainChunksVertexResolution() % width)
+        val xInit = 0 - (calculateRightTerrainChunksVertexResolution() % width)
+
+        for (y in yInit until vertexResolution step width) {
+            if (y >= 0) {
+                for (x in 0 until vertexResolution - 1) {
+                    val current = y * vertexResolution + x
+                    val next = current + 1
+
+                    method.invoke(current.toShort())
+                    method.invoke(next.toShort())
+                }
             }
         }
-        for (y in 0 until vertexResolution step width) {
-            for (x in 0 until  vertexResolution - 1) {
-                val current = y + vertexResolution * x
-                val next = current + vertexResolution
+        for (y in xInit until vertexResolution step width) {
+            if (y >= 0) {
+                for (x in 0 until vertexResolution - 1) {
+                    val current = y + vertexResolution * x
+                    val next = current + vertexResolution
 
-                indices[++i] = current.toShort()
-                indices[++i] = next.toShort()
+                    method.invoke(current.toShort())
+                    method.invoke(next.toShort())
+                }
             }
         }
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/events/TerrainNewNeighborEvent.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/events/TerrainNewNeighborEvent.kt
@@ -1,0 +1,11 @@
+package com.mbrlabs.mundus.editor.events
+
+import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
+
+class TerrainNewNeighborEvent(val terrainComponent: TerrainComponent) {
+
+    interface TerrainNewNeighborEventListener {
+        @Subscribe
+        fun onNewTerrainNeighbor(event: TerrainNewNeighborEvent)
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/history/commands/TerrainNeighborCommand.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/history/commands/TerrainNeighborCommand.kt
@@ -4,6 +4,7 @@ import com.kotcrab.vis.ui.widget.VisTextField
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.events.LogEvent
+import com.mbrlabs.mundus.editor.events.TerrainNewNeighborEvent
 import com.mbrlabs.mundus.editor.history.Command
 
 /**
@@ -11,7 +12,7 @@ import com.mbrlabs.mundus.editor.history.Command
  * @author JamesTKhan
  * @version July 03, 2023
  */
-class TerrainNeighborCommand(var terrainComponent: TerrainComponent?, var neighborString: String) : Command {
+class TerrainNeighborCommand(var terrainComponent: TerrainComponent, var neighborString: String) : Command {
     private var previousNeighbor: TerrainComponent? = null
     private var newNeighbor: TerrainComponent? = null
     private var textField: VisTextField? = null
@@ -19,29 +20,31 @@ class TerrainNeighborCommand(var terrainComponent: TerrainComponent?, var neighb
     init {
         previousNeighbor =
             when (neighborString) {
-                "Left" -> terrainComponent?.leftNeighbor
-                "Right" -> terrainComponent?.rightNeighbor
-                "Top" -> terrainComponent?.topNeighbor
-                "Bottom" -> terrainComponent?.bottomNeighbor
+                "Left" -> terrainComponent.leftNeighbor
+                "Right" -> terrainComponent.rightNeighbor
+                "Top" -> terrainComponent.topNeighbor
+                "Bottom" -> terrainComponent.bottomNeighbor
                 else -> null
             }
     }
 
     override fun execute() {
         setNeighbor(newNeighbor)
-        Mundus.postEvent(LogEvent("$neighborString Terrain neighbor of ${terrainComponent?.gameObject?.name} changed to ${newNeighbor?.gameObject?.name}"))
+        Mundus.postEvent(LogEvent("$neighborString Terrain neighbor of ${terrainComponent.gameObject?.name} changed to ${newNeighbor?.gameObject?.name}"))
+        Mundus.postEvent(TerrainNewNeighborEvent(terrainComponent))
     }
 
     override fun undo() {
         setNeighbor(previousNeighbor)
-        Mundus.postEvent(LogEvent("$neighborString Terrain neighbor of ${terrainComponent?.gameObject?.name} undone back to ${previousNeighbor?.gameObject?.name}"))
+        Mundus.postEvent(LogEvent("$neighborString Terrain neighbor of ${terrainComponent.gameObject?.name} undone back to ${previousNeighbor?.gameObject?.name}"))
+        Mundus.postEvent(TerrainNewNeighborEvent(terrainComponent))
     }
 
     private fun setNeighbor(neighbor: TerrainComponent?) {
-        if (neighborString == "Left") terrainComponent?.leftNeighbor = neighbor
-        if (neighborString == "Right") terrainComponent?.rightNeighbor = neighbor
-        if (neighborString == "Top") terrainComponent?.topNeighbor = neighbor
-        if (neighborString == "Bottom") terrainComponent?.bottomNeighbor = neighbor
+        if (neighborString == "Left") terrainComponent.leftNeighbor = neighbor
+        if (neighborString == "Right") terrainComponent.rightNeighbor = neighbor
+        if (neighborString == "Top") terrainComponent.topNeighbor = neighbor
+        if (neighborString == "Bottom") terrainComponent.bottomNeighbor = neighbor
         textField?.text = neighbor?.gameObject?.name ?: "None"
     }
 


### PR DESCRIPTION
Helper lines support for terrain chunks.

![image](https://github.com/JamesTKhan/Mundus/assets/1684274/afcae4e3-95aa-4913-b019-d9de22b2333a)

Left to do:

- [x] Rectangle helper lines in terrain chunks
- [x] Hexagon helper lines in terrain chunks
- [x] Add helper lines to a new terrain chunks (what is added to an existing terrain system)