### PR TITLE
Fix issues on loading projects

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
@@ -52,6 +52,7 @@ import net.mgsx.gltf.scene3d.shaders.PBRDepthShaderProvider
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.FilenameUtils
 import org.lwjgl.opengl.GL11
+import java.io.File
 
 /**
  * @author Marcus Brummer
@@ -236,6 +237,14 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
             val name = "Default Project"
             var path = FileUtils.getUserDirectoryPath()
             path = FilenameUtils.concat(path, "MundusProjects")
+
+            // If the default project already exists, import it instead of recreate it.
+            // This can happen if the registry was deleted but the project folder was not.
+            val defaultProjectPath = FilenameUtils.concat(path, name)
+            val file = File(defaultProjectPath)
+            if (file.exists()) {
+                return projectManager.importProject(defaultProjectPath)
+            }
 
             return projectManager.createProject(name, path)
         }

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -248,6 +248,13 @@ public class ProjectManager implements Disposable {
             UI.INSTANCE.toggleLoadingScreen(true, context.name);
             ref.setName(context.name);
             registry.getProjects().add(ref);
+
+            // Set this import project as last opened to prevent NPE only
+            // if no project was opened before
+            if (registry.getLastProject() == null){
+                registry.setLastProject(ref);
+            }
+            
             kryoManager.saveRegistry(registry);
             startAsyncProjectLoad(absolutePath, context);
             return context;
@@ -316,6 +323,14 @@ public class ProjectManager implements Disposable {
     public ProjectContext loadLastProjectAsync() {
         ProjectRef lastOpenedProject = registry.getLastOpenedProject();
         if (lastOpenedProject != null) {
+
+            // Check if file exists first
+            File file = new File(lastOpenedProject.getPath());
+            if (!file.exists()) {
+                Log.error(TAG, "Last opened project does not exist: " + lastOpenedProject.getPath());
+                return null;
+            }
+
             try {
                 return startAsyncProjectLoad(lastOpenedProject);
             } catch (FileNotFoundException fnf) {


### PR DESCRIPTION
Fix several issues around how Mundus loads projects. Previously Mundus crashes if the registry is deleted but the default project is still present, that is now fixed. Mundus also crashed if previously opened project was deleted. That is also fixed.

Scenarios tested and passing:

- No registry, no default project
- Registry, no default project
- No registry, has default project already