### PR TITLE
Update Visui to 1.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ allprojects {
     ext {
         appName = "Mundus"
         gdxVersion = '1.12.0'
-        visuiVersion = '1.5.0'
+        visuiVersion = '1.5.2'
         kryoVersion = '5.2.0'
         junitVersion = '4.13.2'
         mockitoVersion = '1.10.19'

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -2,6 +2,7 @@
 - Add dirty transform flag optimization for caching GameObject/SimpleNode world transform
 - Fix Child terrain objects not updating on translation
 - Refactor outline drag and drop world to local conversion code when moving game objects
+- Updated VisUI to 1.5.2
 
 [0.5.1] ~ 08/08/2023
 - Added FPS launcher argument, always call setForegroundFPS


### PR DESCRIPTION
The LibGDX has updated in [this](https://github.com/JamesTKhan/Mundus/pull/204) PR, so I've updated VisUI to 1.5.2, because the current version of VisUI (1.5.0) uses LibGDX 1.10.0.