### PR TITLE
Update KTX to 1.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.6.21'
+    ext.kotlinVersion = '1.9.0'
     repositories {
         mavenCentral()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
         gltfVersion = '2.1.0'
         args4jVersion = '2.33'
 
-        ktxVersion = '1.10.0-b2'
+        ktxVersion = '1.12.0-rc1'
     }
 
     repositories {

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -2,6 +2,8 @@
 - Add dirty transform flag optimization for caching GameObject/SimpleNode world transform
 - Fix Child terrain objects not updating on translation
 - Refactor outline drag and drop world to local conversion code when moving game objects
+- Updated kotlin to 1.9.0
+- Updated KTX to 1.12.0-rc1
 
 [0.5.1] ~ 08/08/2023
 - Added FPS launcher argument, always call setForegroundFPS


### PR DESCRIPTION
This PR is pair of [this](https://github.com/JamesTKhan/Mundus/pull/209) PR. Updates KTX to 1.12.0 because the current KTX uses libGDX version 1.10.0. In this PR I've updated Kotlin also because min 1.9.0 required for KTX 1.12.0.