### PR TITLE
Adjustable lines width

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -2,6 +2,7 @@
 - Add dirty transform flag optimization for caching GameObject/SimpleNode world transform
 - Fix Child terrain objects not updating on translation
 - Refactor outline drag and drop world to local conversion code when moving game objects
+- Adjustable line (selection, wireframe, helper lines) width
 
 [0.5.1] ~ 08/08/2023
 - Added FPS launcher argument, always call setForegroundFPS

--- a/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
@@ -38,6 +38,7 @@ import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.input.FreeCamController
 import com.mbrlabs.mundus.editor.input.InputManager
 import com.mbrlabs.mundus.editor.input.ShortcutController
+import com.mbrlabs.mundus.editor.preferences.MundusPreferencesManager
 import com.mbrlabs.mundus.editor.profiling.MundusGLProfiler
 import com.mbrlabs.mundus.editor.shader.EditorShaderProvider
 import com.mbrlabs.mundus.editor.tools.ToolManager
@@ -78,6 +79,7 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
     private lateinit var glProfiler: MundusGLProfiler
     private lateinit var shapeRenderer: ShapeRenderer
     private lateinit var debugRenderer: DebugRenderer
+    private lateinit var globalPreferencesManager: MundusPreferencesManager
 
     override fun create() {
         Mundus.registerEventListener(this)
@@ -90,6 +92,7 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
         gizmoManager = Mundus.inject()
         glProfiler = Mundus.inject()
         shapeRenderer = Mundus.inject()
+        globalPreferencesManager = Mundus.inject()
         setupInput()
 
         debugRenderer = DebugRenderer(shapeRenderer)
@@ -149,12 +152,15 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
             val renderWireframe = projectManager.current().renderWireframe
             val renderDebug = projectManager.current().renderDebug
 
+
+            Gdx.gl.glLineWidth(globalPreferencesManager.getFloat(MundusPreferencesManager.GLOB_LINE_WIDTH_WIREFRAME, MundusPreferencesManager.GLOB_LINE_WIDTH_DEFAULT_VALUE))
             glProfiler.resume()
             sg.update()
             if (renderWireframe) GL11.glPolygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_LINE)
             scene.render()
             if (renderWireframe) GL11.glPolygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_FILL)
             glProfiler.pause()
+            Gdx.gl.glLineWidth(MundusPreferencesManager.GLOB_LINE_WIDTH_DEFAULT_VALUE)
 
             if (renderDebug) {
                 debugRenderer.begin(scene.cam)
@@ -162,9 +168,11 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
                 debugRenderer.end()
             }
 
+            Gdx.gl.glLineWidth(globalPreferencesManager.getFloat(MundusPreferencesManager.GLOB_LINE_WIDTH_HELPER_LINE, MundusPreferencesManager.GLOB_LINE_WIDTH_DEFAULT_VALUE))
             scene.batch.begin(scene.cam)
             context.helperLines.render(scene.batch)
             scene.batch.end()
+            Gdx.gl.glLineWidth(MundusPreferencesManager.GLOB_LINE_WIDTH_DEFAULT_VALUE)
 
 
             toolManager.render()

--- a/editor/src/main/com/mbrlabs/mundus/editor/preferences/MundusPreferencesManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/preferences/MundusPreferencesManager.kt
@@ -16,9 +16,13 @@ class MundusPreferencesManager(preferencesKey: String) : PreferencesManager {
         // Keys for global prefs
         const val GLOB_MUNDUS_VERSION = "version"
         const val GLOB_RIGHT_BUTTON_SELECT = "right-button-select"
+        const val GLOB_LINE_WIDTH_SELECTION = "line-width-selection"
+        const val GLOB_LINE_WIDTH_WIREFRAME = "line-width-wireframe"
+        const val GLOB_LINE_WIDTH_HELPER_LINE = "line-width-helper-line"
 
         // Default values for global prefs
         const val GLOB_RIGHT_SELECT_BUTTON_DEFAULT_VALUE = true
+        const val GLOB_LINE_WIDTH_DEFAULT_VALUE = 1.0f
 
         // Keys for project specific prefs
         const val PROJ_LAST_DIR = "lastDirectoryOpened"

--- a/editor/src/main/com/mbrlabs/mundus/editor/tools/SelectionTool.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/tools/SelectionTool.java
@@ -15,6 +15,7 @@
  */
 package com.mbrlabs.mundus.editor.tools;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
@@ -72,6 +73,7 @@ public class SelectionTool extends Tool {
     @Override
     public void render() {
         if (getProjectManager().current().currScene.currentSelection != null) {
+            Gdx.gl.glLineWidth(globalPreferencesManager.getFloat(MundusPreferencesManager.GLOB_LINE_WIDTH_SELECTION, MundusPreferencesManager.GLOB_LINE_WIDTH_DEFAULT_VALUE));
             getProjectManager().getModelBatch().begin(getProjectManager().current().currScene.cam);
             for (GameObject go : getProjectManager().current().currScene.currentSelection) {
                 // model component
@@ -93,6 +95,7 @@ public class SelectionTool extends Tool {
                 }
             }
             getProjectManager().getModelBatch().end();
+            Gdx.gl.glLineWidth(MundusPreferencesManager.GLOB_LINE_WIDTH_DEFAULT_VALUE);
         }
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/AppearanceSettingsTable.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/AppearanceSettingsTable.kt
@@ -16,7 +16,14 @@
 
 package com.mbrlabs.mundus.editor.ui.modules.dialogs.settings
 
+import com.kotcrab.vis.ui.util.FloatDigitsOnlyFilter
 import com.kotcrab.vis.ui.widget.VisLabel
+import com.kotcrab.vis.ui.widget.VisTextField
+import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.events.LogEvent
+import com.mbrlabs.mundus.editor.events.LogType
+import com.mbrlabs.mundus.editor.preferences.MundusPreferencesManager
+import com.mbrlabs.mundus.editor.ui.UI
 
 /**
  * @author Marcus Brummer
@@ -24,16 +31,62 @@ import com.kotcrab.vis.ui.widget.VisLabel
  */
 class AppearanceSettingsTable : BaseSettingsTable() {
 
+    private val globalPreferencesManager : MundusPreferencesManager = Mundus.inject()
+
+    private val selectionLineWidth = VisTextField("0")
+    private val wireframeLineWidth = VisTextField("0")
+    private val helperLineWidth = VisTextField("0")
+
     init {
         top().left()
+        defaults().left()//.pad(4f)
         padRight(5f).padLeft(6f)
+
+        selectionLineWidth.textFieldFilter = FloatDigitsOnlyFilter(false)
+        wireframeLineWidth.textFieldFilter = FloatDigitsOnlyFilter(false)
+        helperLineWidth.textFieldFilter = FloatDigitsOnlyFilter(false)
 
         add(VisLabel("Appearance Settings")).left().row()
         addSeparator().padBottom(10f)
+
+        add(VisLabel("Selection line width")).row()
+        add(selectionLineWidth).padBottom(4f).row()
+
+        add(VisLabel("Wireframe line width")).row()
+        add(wireframeLineWidth).padBottom(4f).row()
+
+        add(VisLabel("Helper line width")).row()
+        add(helperLineWidth).padBottom(4f).row()
+
+        loadValues()
+    }
+
+    private fun loadValues() {
+        selectionLineWidth.text = globalPreferencesManager.getFloat(MundusPreferencesManager.GLOB_LINE_WIDTH_SELECTION, MundusPreferencesManager.GLOB_LINE_WIDTH_DEFAULT_VALUE).toString()
+        wireframeLineWidth.text = globalPreferencesManager.getFloat(MundusPreferencesManager.GLOB_LINE_WIDTH_WIREFRAME, MundusPreferencesManager.GLOB_LINE_WIDTH_DEFAULT_VALUE).toString()
+        helperLineWidth.text = globalPreferencesManager.getFloat(MundusPreferencesManager.GLOB_LINE_WIDTH_HELPER_LINE, MundusPreferencesManager.GLOB_LINE_WIDTH_DEFAULT_VALUE).toString()
     }
 
     override fun onSave() {
+        try {
+            globalPreferencesManager.set(MundusPreferencesManager.GLOB_LINE_WIDTH_SELECTION, selectionLineWidth.text.toFloat())
+        } catch (ex : NumberFormatException) {
+            Mundus.postEvent(LogEvent(LogType.ERROR,"Error parsing field " + selectionLineWidth.name))
+        }
 
+        try {
+            globalPreferencesManager.set(MundusPreferencesManager.GLOB_LINE_WIDTH_WIREFRAME, wireframeLineWidth.text.toFloat())
+        } catch (ex : NumberFormatException) {
+            Mundus.postEvent(LogEvent(LogType.ERROR,"Error parsing field " + wireframeLineWidth.name))
+        }
+
+        try {
+            globalPreferencesManager.set(MundusPreferencesManager.GLOB_LINE_WIDTH_HELPER_LINE, helperLineWidth.text.toFloat())
+        } catch (ex : NumberFormatException) {
+            Mundus.postEvent(LogEvent(LogType.ERROR,"Error parsing field " + helperLineWidth.name))
+        }
+
+        UI.toaster.success("Settings saved")
     }
 
 }


### PR DESCRIPTION
The default line width is 1.0 and it is too thin sometimes.

There are 3 types of line:
- Object selection
- Wireframe mode
- Helper lines

The width of these lines can be changed in the settings menu:
![image](https://github.com/JamesTKhan/Mundus/assets/1684274/29bb46b8-5b4c-4faf-9f82-e077b00d7768)
