### PR TITLE
Add get forward direction method

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/Node.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/Node.java
@@ -150,6 +150,13 @@ public interface Node<T extends Node> {
     Matrix4 getTransform();
 
     /**
+     * Gets the current forward direction, assumes the default forward direction is Z+.
+     *
+     * @param out out vector to be populated with direction
+     */
+    Vector3 getForwardDirection(Vector3 out);
+
+    /**
      * Translates the position of this node.
      *
      * @param v

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SimpleNode.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SimpleNode.java
@@ -30,6 +30,8 @@ public class SimpleNode<T extends SimpleNode> extends BaseNode<T> {
 
     static boolean WORLD_SPACE_TRANSFORM = true;
 
+    private static final Vector3 LOCAL_FORWARD = new Vector3(0, 0, 1);
+
     private final Vector3 localPosition;
     private final Quaternion localRotation;
     private final Vector3 localScale;
@@ -104,6 +106,11 @@ public class SimpleNode<T extends SimpleNode> extends BaseNode<T> {
             isTransformDirty = false;
         }
         return combined;
+    }
+
+    @Override
+    public Vector3 getForwardDirection(Vector3 out) {
+        return out.set(LOCAL_FORWARD).rot(getTransform()).nor();
     }
 
     @Override


### PR DESCRIPTION
Add new convenience method for getting a GameObject/SimpleNode/Node's current forward direction.
