### PR TITLE
Scale transform tools on act()

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -14,6 +14,8 @@
 - Fix Material culling value being reset to GL_NONE by editor
 - Fix crash on Asset Usage tool when Light Component in scene
 - Updated libGDX to 1.12.0
+- Fix Previous project's inspector data persists after switching project
+- Fix transform tools scale with camera distance
 
 [0.5.0] ~ 06/28/2023
 - [Breaking Change] Lighting systems updated, visibly different. See PR#184

--- a/editor/src/main/com/mbrlabs/mundus/editor/tools/RotateTool.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/tools/RotateTool.java
@@ -149,6 +149,8 @@ public class RotateTool extends TransformTool {
         ProjectContext projectContext = getProjectManager().current();
         if (projectContext.currScene.currentSelection != null) {
             translateHandles();
+            scaleHandles();
+
             if (state == TransformState.IDLE) {
                 return;
             }

--- a/editor/src/main/com/mbrlabs/mundus/editor/tools/ScaleTool.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/tools/ScaleTool.java
@@ -184,6 +184,8 @@ public class ScaleTool extends TransformTool {
 
         if (selection!= null) {
             translateHandles();
+            scaleHandles();
+
             if (state == TransformState.IDLE) {
                 return;
             }

--- a/editor/src/main/com/mbrlabs/mundus/editor/tools/TranslateTool.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/tools/TranslateTool.java
@@ -159,6 +159,8 @@ public class TranslateTool extends TransformTool {
 
         if (getProjectManager().current().currScene.currentSelection != null) {
             translateHandles();
+            scaleHandles();
+
             if (state == TransformState.IDLE) return;
 
             Ray ray = getProjectManager().current().currScene.viewport.getPickRay(Gdx.input.getX(), Gdx.input.getY());


### PR DESCRIPTION
Per tool scaling did not rebase abstracts.