### PR TITLE
Add OBB to cullables

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
@@ -21,6 +21,7 @@ import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.math.collision.BoundingBox;
+import com.badlogic.gdx.math.collision.OrientedBoundingBox;
 import com.badlogic.gdx.utils.Array;
 import com.mbrlabs.mundus.commons.event.Event;
 import com.mbrlabs.mundus.commons.event.EventType;
@@ -48,6 +49,7 @@ public abstract class CullableComponent extends AbstractComponent implements Mod
 
     protected final Vector3 center = new Vector3();
     protected final Vector3 dimensions = new Vector3();
+    private final OrientedBoundingBox orientedBoundingBox = new OrientedBoundingBox();
     protected float radius;
 
     // Render calls since last cull check
@@ -68,6 +70,10 @@ public abstract class CullableComponent extends AbstractComponent implements Mod
 
         if (gameObject.scaleChanged) {
             setDimensions(modelInstance);
+        }
+
+        if (gameObject.isDirty()) {
+            orientedBoundingBox.setTransform(modelInstance.transform);
         }
 
         if (!gameObject.sceneGraph.scene.settings.useFrustumCulling) {
@@ -144,6 +150,11 @@ public abstract class CullableComponent extends AbstractComponent implements Mod
         gameObject.getScale(tmpScale);
         dimensions.scl(tmpScale);
         radius = dimensions.len() / 2f;
+        orientedBoundingBox.set(tmpBounds, modelInstance.transform);
+    }
+
+    public OrientedBoundingBox getOrientedBoundingBox() {
+        return orientedBoundingBox;
     }
 
     private void triggerEvent(final EventType eventType) {

--- a/commons/src/main/com/mbrlabs/mundus/commons/utils/DebugRenderer.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/utils/DebugRenderer.java
@@ -1,9 +1,21 @@
 package com.mbrlabs.mundus.commons.utils;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.VertexAttributes;
+import com.badlogic.gdx.graphics.g3d.Material;
+import com.badlogic.gdx.graphics.g3d.Model;
+import com.badlogic.gdx.graphics.g3d.ModelBatch;
+import com.badlogic.gdx.graphics.g3d.ModelInstance;
+import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
+import com.badlogic.gdx.graphics.g3d.utils.MeshPartBuilder;
+import com.badlogic.gdx.graphics.g3d.utils.shapebuilders.BoxShapeBuilder;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.math.collision.OrientedBoundingBox;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
@@ -13,21 +25,32 @@ import com.mbrlabs.mundus.commons.scene3d.components.ModelComponent;
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent;
 import com.mbrlabs.mundus.commons.scene3d.components.WaterComponent;
 
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
 /**
  * Simple debug renderer that only renders bounding boxes of {@link CullableComponent}
- *  which are used for frustum culling.
+ * which are used for frustum culling.
  *
  * @author JamesTKhan
  * @version July 25, 2022
  */
 public class DebugRenderer implements Renderer, Disposable {
-    private static final Vector3 tmpPos = new Vector3();
-    private static final Vector3 tmpCenter = new Vector3();
+    private static final OrientedBoundingBox tmpObb = new OrientedBoundingBox();
 
-    private final ShapeRenderer shapeRenderer;
+    // Shape Renderer
     private final boolean ownsShapeRenderer;
-
+    private final ShapeRenderer shapeRenderer;
     private ShapeRenderer.ShapeType shapeType = ShapeRenderer.ShapeType.Line;
+
+    // Model Renderer
+    private ModelBatch modelBatch;
+    private final Map<Component, ModelInstance> modelInstancesCache = new HashMap<>();
+    private final Array<ModelInstance> instances = new Array<>();
+
+    // Debug settings
+    private boolean appearOnTop = true;
 
     public DebugRenderer() {
         shapeRenderer = new ShapeRenderer();
@@ -36,6 +59,7 @@ public class DebugRenderer implements Renderer, Disposable {
 
     public DebugRenderer(ShapeRenderer shapeRenderer) {
         this.shapeRenderer = shapeRenderer;
+        modelBatch = new ModelBatch();
         ownsShapeRenderer = false;
     }
 
@@ -45,15 +69,34 @@ public class DebugRenderer implements Renderer, Disposable {
 
     @Override
     public void begin(Camera camera) {
-        shapeRenderer.begin(shapeType);
-        shapeRenderer.setProjectionMatrix(camera.combined);
+        if (appearOnTop) {
+            // Clearing depth puts the model debug lines on top of everything else
+            Gdx.gl.glClear(GL20.GL_DEPTH_BUFFER_BIT);
+        }
+        modelBatch.begin(camera);
     }
 
     @Override
     public void render(Array<GameObject> gameObjects) {
+        instances.clear();
         for (GameObject object : gameObjects) {
             render(object);
         }
+        modelBatch.render(instances);
+
+        // If it's in the cache but not in instances, remove from cache
+        Iterator<Map.Entry<Component, ModelInstance>> it = modelInstancesCache.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Component, ModelInstance> item = it.next();
+            if (!instances.contains(item.getValue(), true)) {
+                // Dispose the debug model
+                item.getValue().model.dispose();
+                it.remove();
+            }
+        }
+
+
+        // Any shape rendering should be done here if needed
     }
 
     @Override
@@ -68,19 +111,18 @@ public class DebugRenderer implements Renderer, Disposable {
             }
 
             CullableComponent cullableComponent = (CullableComponent) component;
-            go.getPosition(tmpPos);
-            tmpCenter.set(cullableComponent.getCenter());
-            tmpPos.add(tmpCenter);
 
-            shapeRenderer.setColor(getColor(component));
-            shapeRenderer.box(
-                    tmpPos.x - (cullableComponent.getDimensions().x / 2),
-                    tmpPos.y - (cullableComponent.getDimensions().y / 2),
-                    tmpPos.z + (cullableComponent.getDimensions().z / 2),
-                    cullableComponent.getDimensions().x,
-                    cullableComponent.getDimensions().y,
-                    cullableComponent.getDimensions().z);
-            shapeRenderer.point(tmpCenter.x, tmpCenter.y, tmpCenter.z);
+            if (!modelInstancesCache.containsKey(component)) {
+                OrientedBoundingBox orientedBoundingBox = cullableComponent.getOrientedBoundingBox();
+                if (orientedBoundingBox == null) continue;
+                tmpObb.set(orientedBoundingBox.getBounds(), new Matrix4());
+                Model model = buildModel(tmpObb, getColor(component));
+                modelInstancesCache.put(component, new ModelInstance(model));
+            }
+
+            ModelInstance modelInstance = modelInstancesCache.get(component);
+            modelInstance.transform.set(cullableComponent.getOrientedBoundingBox().getTransform());
+            instances.add(modelInstance);
         }
 
         if (go.getChildren() == null) return;
@@ -93,7 +135,7 @@ public class DebugRenderer implements Renderer, Disposable {
 
     @Override
     public void end() {
-        shapeRenderer.end();
+        modelBatch.end();
     }
 
     protected Color getColor(Component component) {
@@ -112,5 +154,41 @@ public class DebugRenderer implements Renderer, Disposable {
         if (ownsShapeRenderer) {
             shapeRenderer.dispose();
         }
+
+        if (modelBatch != null) {
+            modelBatch.dispose();
+        }
+
+        // Dispose all cached models
+        Iterator<Map.Entry<Component, ModelInstance>> it = modelInstancesCache.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Component, ModelInstance> item = it.next();
+            // Dispose the debug model
+            item.getValue().model.dispose();
+            it.remove();
+        }
+    }
+
+    /**
+     * Builds a model for the given oriented bounding box.
+     * @param orientedBoundingBox the oriented bounding box
+     * @param color the color of the model
+     * @return the model
+     */
+    private Model buildModel(OrientedBoundingBox orientedBoundingBox, Color color) {
+        Material material = new Material(ColorAttribute.createDiffuse(color));
+        com.badlogic.gdx.graphics.g3d.utils.ModelBuilder mb = new com.badlogic.gdx.graphics.g3d.utils.ModelBuilder();
+        mb.begin();
+        MeshPartBuilder meshPartBuilder = mb.part("debug_box", GL20.GL_LINES, VertexAttributes.Usage.Position, material);
+        BoxShapeBuilder.build(meshPartBuilder, orientedBoundingBox.getCorner000(new Vector3()),
+                orientedBoundingBox.getCorner010(new Vector3()), orientedBoundingBox.getCorner100(new Vector3()),
+                orientedBoundingBox.getCorner110(new Vector3()), orientedBoundingBox.getCorner001(new Vector3()),
+                orientedBoundingBox.getCorner011(new Vector3()), orientedBoundingBox.getCorner101(new Vector3()),
+                orientedBoundingBox.getCorner111(new Vector3()));
+        return mb.end();
+    }
+
+    public void setAppearOnTop(boolean appearOnTop) {
+        this.appearOnTop = appearOnTop;
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/utils/DebugRenderer.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/utils/DebugRenderer.java
@@ -191,4 +191,8 @@ public class DebugRenderer implements Renderer, Disposable {
     public void setAppearOnTop(boolean appearOnTop) {
         this.appearOnTop = appearOnTop;
     }
+
+    public boolean isAppearOnTop() {
+        return appearOnTop;
+    }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/utils/DebugRenderer.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/utils/DebugRenderer.java
@@ -51,6 +51,7 @@ public class DebugRenderer implements Renderer, Disposable {
 
     // Debug settings
     private boolean appearOnTop = true;
+    private boolean enabled = false;
 
     public DebugRenderer() {
         shapeRenderer = new ShapeRenderer();
@@ -69,6 +70,8 @@ public class DebugRenderer implements Renderer, Disposable {
 
     @Override
     public void begin(Camera camera) {
+        if (!enabled) return;
+
         if (appearOnTop) {
             // Clearing depth puts the model debug lines on top of everything else
             Gdx.gl.glClear(GL20.GL_DEPTH_BUFFER_BIT);
@@ -101,6 +104,7 @@ public class DebugRenderer implements Renderer, Disposable {
 
     @Override
     public void render(GameObject go) {
+        if (!enabled) return;
         if (!go.active) return;
 
         for (Component component : go.getComponents()) {
@@ -135,6 +139,7 @@ public class DebugRenderer implements Renderer, Disposable {
 
     @Override
     public void end() {
+        if (!enabled) return;
         modelBatch.end();
     }
 
@@ -171,8 +176,9 @@ public class DebugRenderer implements Renderer, Disposable {
 
     /**
      * Builds a model for the given oriented bounding box.
+     *
      * @param orientedBoundingBox the oriented bounding box
-     * @param color the color of the model
+     * @param color               the color of the model
      * @return the model
      */
     private Model buildModel(OrientedBoundingBox orientedBoundingBox, Color color) {
@@ -194,5 +200,13 @@ public class DebugRenderer implements Renderer, Disposable {
 
     public boolean isAppearOnTop() {
         return appearOnTop;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 }

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -1,5 +1,6 @@
 [0.6.0] ~
 - Add dirty transform flag optimization for caching GameObject/SimpleNode world transform
+- Add OrientedBoundingBox to cullable components, update debug renderer to use it
 - Fix Child terrain objects not updating on translation
 - Refactor outline drag and drop world to local conversion code when moving game objects
 - Updated kotlin to 1.9.0

--- a/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
@@ -96,6 +96,9 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
         globalPreferencesManager = Mundus.inject()
         setupInput()
 
+        debugRenderer.isEnabled = globalPreferencesManager.getBoolean(MundusPreferencesManager.GLOB_BOOL_DEBUG_RENDERER_ON, false)
+        debugRenderer.isAppearOnTop = globalPreferencesManager.getBoolean(MundusPreferencesManager.GLOB_BOOL_DEBUG_RENDERER_DEPTH_OFF, false)
+
         // TODO dispose this
         val axesModel = UsefulMeshs.createAxes()
         axesInstance = ModelInstance(axesModel)
@@ -149,8 +152,6 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
         UI.sceneWidget.setCam(context.currScene.cam)
         UI.sceneWidget.setRenderer {
             val renderWireframe = projectManager.current().renderWireframe
-            val renderDebug = projectManager.current().renderDebug
-
 
             Gdx.gl.glLineWidth(globalPreferencesManager.getFloat(MundusPreferencesManager.GLOB_LINE_WIDTH_WIREFRAME, MundusPreferencesManager.GLOB_LINE_WIDTH_DEFAULT_VALUE))
             glProfiler.resume()
@@ -161,7 +162,7 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
             glProfiler.pause()
             Gdx.gl.glLineWidth(MundusPreferencesManager.GLOB_LINE_WIDTH_DEFAULT_VALUE)
 
-            if (renderDebug) {
+            if (debugRenderer.isEnabled) {
                 debugRenderer.begin(scene.cam)
                 debugRenderer.render(sg.gameObjects)
                 debugRenderer.end()

--- a/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
@@ -92,10 +92,9 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
         gizmoManager = Mundus.inject()
         glProfiler = Mundus.inject()
         shapeRenderer = Mundus.inject()
+        debugRenderer = Mundus.inject()
         globalPreferencesManager = Mundus.inject()
         setupInput()
-
-        debugRenderer = DebugRenderer(shapeRenderer)
 
         // TODO dispose this
         val axesModel = UsefulMeshs.createAxes()

--- a/editor/src/main/com/mbrlabs/mundus/editor/Mundus.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Mundus.kt
@@ -117,7 +117,7 @@ object Mundus {
         toolManager = ToolManager(input, projectManager, goPicker, handlePicker, shapeRenderer,
                 commandHistory, globalPrefManager)
         gizmoManager = GizmoManager()
-        shortcutController = ShortcutController(registry, projectManager, commandHistory, toolManager)
+        shortcutController = ShortcutController(registry, projectManager, commandHistory, toolManager, debugRenderer, globalPrefManager)
         json = Json()
         glProfiler = MundusGLProfiler(Gdx.graphics)
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/Mundus.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Mundus.kt
@@ -27,6 +27,7 @@ import com.badlogic.gdx.utils.Json
 import com.kotcrab.vis.ui.VisUI
 import com.kotcrab.vis.ui.widget.file.FileChooser
 import com.mbrlabs.mundus.commons.assets.meta.MetaLoader
+import com.mbrlabs.mundus.commons.utils.DebugRenderer
 import com.mbrlabs.mundus.editor.preferences.MundusPreferencesManager
 import com.mbrlabs.mundus.editor.assets.MetaSaver
 import com.mbrlabs.mundus.editor.assets.ModelImporter
@@ -73,6 +74,7 @@ object Mundus {
     private val freeCamController: FreeCamController
     private val shortcutController: ShortcutController
     private val shapeRenderer: ShapeRenderer
+    private val debugRenderer: DebugRenderer
     private val kryoManager: KryoManager
     private val projectManager: ProjectManager
     private val registry: Registry
@@ -100,6 +102,7 @@ object Mundus {
 
         // DI
         shapeRenderer = ShapeRenderer()
+        debugRenderer = DebugRenderer(shapeRenderer)
         modelBatch = ModelBatch()
         input = InputManager()
         goPicker = GameObjectPicker()
@@ -121,6 +124,7 @@ object Mundus {
         // add to DI container
         context.register {
             bindSingleton(shapeRenderer)
+            bindSingleton(debugRenderer)
             bindSingleton(input)
             bindSingleton(goPicker)
             bindSingleton(handlePicker)

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectContext.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectContext.java
@@ -52,8 +52,6 @@ public class ProjectContext implements Disposable {
 
     public EditorAssetManager assetManager;
     public MundusPreferencesManager projectPref;
-
-    public boolean renderDebug = false;
     public boolean renderWireframe = false;
 
     public HelperLines helperLines;

--- a/editor/src/main/com/mbrlabs/mundus/editor/input/ShortcutController.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/input/ShortcutController.kt
@@ -18,9 +18,11 @@ package com.mbrlabs.mundus.editor.input
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.Input
+import com.mbrlabs.mundus.commons.utils.DebugRenderer
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.core.registry.Registry
 import com.mbrlabs.mundus.editor.history.CommandHistory
+import com.mbrlabs.mundus.editor.preferences.MundusPreferencesManager
 import com.mbrlabs.mundus.editor.tools.ToolManager
 import com.mbrlabs.mundus.editor.ui.UI
 
@@ -28,7 +30,14 @@ import com.mbrlabs.mundus.editor.ui.UI
  * @author Marcus Brummer
  * @version 07-02-2016
  */
-class ShortcutController(registry: Registry, private val projectManager: ProjectManager, private val history: CommandHistory, private val toolManager: ToolManager)
+class ShortcutController(
+    registry: Registry,
+    private val projectManager: ProjectManager,
+    private val history: CommandHistory,
+    private val toolManager: ToolManager,
+    private val debugRenderer: DebugRenderer,
+    private val globalPrefManager: MundusPreferencesManager
+)
     : KeyboardLayoutInputAdapter(registry) {
 
     private var isCtrlPressed = false
@@ -80,7 +89,8 @@ class ShortcutController(registry: Registry, private val projectManager: Project
             toolManager.activateTool(toolManager.selectionTool)
             UI.toolbar.updateActiveToolButton()
         } else if (keycode == Input.Keys.F2) {
-            projectManager.current().renderDebug = !projectManager.current().renderDebug
+            debugRenderer.isEnabled = !debugRenderer.isEnabled
+            globalPrefManager.set(MundusPreferencesManager.GLOB_BOOL_DEBUG_RENDERER_ON, debugRenderer.isEnabled)
         } else if (keycode == Input.Keys.F3) {
             projectManager.current().renderWireframe = !projectManager.current().renderWireframe
         }

--- a/editor/src/main/com/mbrlabs/mundus/editor/preferences/MundusPreferencesManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/preferences/MundusPreferencesManager.kt
@@ -13,18 +13,22 @@ class MundusPreferencesManager(preferencesKey: String) : PreferencesManager {
     companion object {
         private val TAG = MundusPreferencesManager::class.java.simpleName
 
-        // Keys for global prefs
+        /** Keys for global prefs **/
         const val GLOB_MUNDUS_VERSION = "version"
         const val GLOB_RIGHT_BUTTON_SELECT = "right-button-select"
         const val GLOB_LINE_WIDTH_SELECTION = "line-width-selection"
         const val GLOB_LINE_WIDTH_WIREFRAME = "line-width-wireframe"
         const val GLOB_LINE_WIDTH_HELPER_LINE = "line-width-helper-line"
 
+        // Debug renderer settings
+        const val GLOB_BOOL_DEBUG_RENDERER_ON = "debug-renderer-on"
+        const val GLOB_BOOL_DEBUG_RENDERER_DEPTH_OFF = "debug-renderer-depth-off"
+
         // Default values for global prefs
         const val GLOB_RIGHT_SELECT_BUTTON_DEFAULT_VALUE = true
         const val GLOB_LINE_WIDTH_DEFAULT_VALUE = 1.0f
 
-        // Keys for project specific prefs
+        /** Keys for project specific prefs **/
         const val PROJ_LAST_DIR = "lastDirectoryOpened"
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/tools/DebugRenderDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/tools/DebugRenderDialog.kt
@@ -10,6 +10,7 @@ import com.kotcrab.vis.ui.widget.VisRadioButton
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.spinner.IntSpinnerModel
 import com.kotcrab.vis.ui.widget.spinner.Spinner
+import com.mbrlabs.mundus.commons.utils.DebugRenderer
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.helperlines.HelperLineType
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
@@ -23,6 +24,7 @@ class DebugRenderDialog : BaseDialog(TITLE) {
     }
 
     private val showBoundingBoxes = VisCheckBox(null)
+    private val showBoundingBoxesOnTop = VisCheckBox(null)
     private val wireFrameMode = VisCheckBox(null)
     private val helperLines = VisCheckBox(null)
     private val rectangleRadio = VisRadioButton("Rectangle")
@@ -30,6 +32,8 @@ class DebugRenderDialog : BaseDialog(TITLE) {
     private val columnSpinnerModel = IntSpinnerModel(2, 2, 100)
     private val columnSpinner = Spinner("Column:", columnSpinnerModel)
     private val projectManager: ProjectManager = Mundus.inject()
+
+    private val debugRenderer: DebugRenderer = Mundus.inject()
 
     init {
         setupUI()
@@ -45,6 +49,8 @@ class DebugRenderDialog : BaseDialog(TITLE) {
         rectangleRadio.touchable = touchable
         hexagonRadio.touchable = touchable
         columnSpinner.touchable = touchable
+
+        showBoundingBoxesOnTop.isChecked = debugRenderer.isAppearOnTop
 
         return super.show(stage)
     }
@@ -67,6 +73,9 @@ class DebugRenderDialog : BaseDialog(TITLE) {
                 "\nthe bounding boxes reflect what frustum culling will use when determining to cull an object. Hotkey: CTRL+F2")).left()
         table.add(showBoundingBoxes).left().padBottom(10f).row()
 
+        table.add(ToolTipLabel("Render Debug On Top", "Whether the render debug lines with depth or not.")).left()
+        table.add(showBoundingBoxesOnTop).left().padBottom(10f).row()
+
         table.add(ToolTipLabel("Wireframe Mode", "Uses OpenGL glPolygonMode with GL_LINE to show wireframe.  Hotkey: CTRL+F3")).left()
         table.add(wireFrameMode).left().padBottom(10f).row()
 
@@ -83,6 +92,12 @@ class DebugRenderDialog : BaseDialog(TITLE) {
         showBoundingBoxes.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent?, actor: Actor?) {
                 projectManager.current().renderDebug = !projectManager.current().renderDebug
+            }
+        })
+
+        showBoundingBoxesOnTop.addListener(object : ChangeListener() {
+            override fun changed(event: ChangeEvent?, actor: Actor?) {
+                debugRenderer.isAppearOnTop = showBoundingBoxesOnTop.isChecked
             }
         })
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/tools/DebugRenderDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/tools/DebugRenderDialog.kt
@@ -14,6 +14,7 @@ import com.mbrlabs.mundus.commons.utils.DebugRenderer
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.helperlines.HelperLineType
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
+import com.mbrlabs.mundus.editor.preferences.MundusPreferencesManager
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.BaseDialog
 import com.mbrlabs.mundus.editor.ui.widgets.ToolTipLabel
 
@@ -31,8 +32,9 @@ class DebugRenderDialog : BaseDialog(TITLE) {
     private val hexagonRadio = VisRadioButton("Hexagon")
     private val columnSpinnerModel = IntSpinnerModel(2, 2, 100)
     private val columnSpinner = Spinner("Column:", columnSpinnerModel)
-    private val projectManager: ProjectManager = Mundus.inject()
 
+    private val projectManager: ProjectManager = Mundus.inject()
+    private val preferencesManager : MundusPreferencesManager = Mundus.inject()
     private val debugRenderer: DebugRenderer = Mundus.inject()
 
     init {
@@ -62,7 +64,7 @@ class DebugRenderDialog : BaseDialog(TITLE) {
             toggle(wireFrameMode)
         }
 
-        if (projectManager.current().renderDebug != showBoundingBoxes.isChecked) {
+        if (debugRenderer.isEnabled != showBoundingBoxes.isChecked) {
             toggle(showBoundingBoxes)
         }
     }
@@ -91,13 +93,15 @@ class DebugRenderDialog : BaseDialog(TITLE) {
     private fun setupListeners() {
         showBoundingBoxes.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent?, actor: Actor?) {
-                projectManager.current().renderDebug = !projectManager.current().renderDebug
+                debugRenderer.isEnabled = showBoundingBoxes.isChecked
+                preferencesManager.set(MundusPreferencesManager.GLOB_BOOL_DEBUG_RENDERER_ON, showBoundingBoxes.isChecked)
             }
         })
 
         showBoundingBoxesOnTop.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent?, actor: Actor?) {
                 debugRenderer.isAppearOnTop = showBoundingBoxesOnTop.isChecked
+                preferencesManager.set(MundusPreferencesManager.GLOB_BOOL_DEBUG_RENDERER_DEPTH_OFF, showBoundingBoxesOnTop.isChecked)
             }
         })
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/tools/DebugRenderDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/tools/DebugRenderDialog.kt
@@ -75,7 +75,7 @@ class DebugRenderDialog : BaseDialog(TITLE) {
                 "\nthe bounding boxes reflect what frustum culling will use when determining to cull an object. Hotkey: CTRL+F2")).left()
         table.add(showBoundingBoxes).left().padBottom(10f).row()
 
-        table.add(ToolTipLabel("Render Debug On Top", "Whether the render debug lines with depth or not.")).left()
+        table.add(ToolTipLabel("Render Debug On Top", "Whether to render debug lines with depth or not.")).left()
         table.add(showBoundingBoxesOnTop).left().padBottom(10f).row()
 
         table.add(ToolTipLabel("Wireframe Mode", "Uses OpenGL glPolygonMode with GL_LINE to show wireframe.  Hotkey: CTRL+F3")).left()


### PR DESCRIPTION
libGDX has something called OrientedBoundingBox. This fixes the bounding boxes not rendering rotations properly by using models/modelbatch + Oriented Bounding Box for the debug lines instead of shape renderer

The added bonus is that now all CullableComponents have actual dedicated Oriented bounding boxes, and this could be used for basic collision detection as well in the runtime as well. The downfall is slightly more memory overhead.

Another addition is the option to render debug lines with or without depth. 

Also added preferences saving for debug renderer options so user preference will persist on editor close

https://github.com/JamesTKhan/Mundus/assets/28971753/63b13523-a9b3-4eb2-a25b-62bd2235586d


https://github.com/JamesTKhan/Mundus/assets/28971753/7b55f849-e760-412f-ba26-17a51f4690f4

