### PR TITLE
Align To Camera / Align to Object actions

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SimpleNode.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SimpleNode.java
@@ -88,7 +88,7 @@ public class SimpleNode<T extends SimpleNode> extends BaseNode<T> {
 
     @Override
     public Quaternion getRotation(Quaternion out) {
-        return getTransform().getRotation(out);
+        return getTransform().getRotation(out, true);
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/utils/Pools.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/utils/Pools.java
@@ -1,5 +1,7 @@
 package com.mbrlabs.mundus.commons.utils;
 
+import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.math.Quaternion;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Pool;
@@ -33,6 +35,30 @@ public class Pools {
         @Override
         protected void reset(Vector3 object) {
             object.set(0,0,0);
+        }
+    };
+
+    public final static Pool<Quaternion> quaternionPool = new Pool<Quaternion>(2) {
+        @Override
+        protected Quaternion newObject () {
+            return new Quaternion();
+        }
+
+        @Override
+        protected void reset(Quaternion object) {
+            object.idt();
+        }
+    };
+
+    public final static Pool<Matrix4> matrix4Pool = new Pool<Matrix4>(2) {
+        @Override
+        protected Matrix4 newObject () {
+            return new Matrix4();
+        }
+
+        @Override
+        protected void reset(Matrix4 object) {
+            object.idt();
         }
     };
 

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -2,7 +2,10 @@
 - [BREAKING CHANGE] Migrated from Kryo to JSON for .registry and .pro files. Migration handled automatically.
 - Add dirty transform flag optimization for caching GameObject/SimpleNode world transform
 - Add OrientedBoundingBox to cullable components, update debug renderer to use it
+- Add "Align Camera to Object" and "Align Object to Camera" actions
+- Add Quaternion and Matrix4 pools
 - Fix Child terrain objects not updating on translation
+- Fix getRotation() in SimpleNode to always normalize axes
 - Refactor outline drag and drop world to local conversion code when moving game objects
 - Updated kotlin to 1.9.0
 - Updated KTX to 1.12.0-rc1

--- a/editor/src/main/com/mbrlabs/mundus/editor/history/commands/MultiCommand.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/history/commands/MultiCommand.kt
@@ -1,0 +1,33 @@
+package com.mbrlabs.mundus.editor.history.commands
+
+import com.badlogic.gdx.utils.Array
+import com.mbrlabs.mundus.editor.history.Command
+
+/**
+ * A wrapper that Executes multiple commands at once.
+ * Useful if you perform an action using multiple commands (Ex. Scale+Rotate object)
+ * and you want to execute both in a single undo/redo step.
+ *
+ * @author JamesTKhan
+ * @version August 27, 2023
+ */
+class MultiCommand : Command {
+    private var commands = Array<Command>()
+
+    override fun execute() {
+        for (command in commands) {
+            command.execute()
+        }
+    }
+
+    override fun undo() {
+        // undo, but in reverse order
+        for (i in commands.size - 1 downTo 0) {
+            commands[i].undo()
+        }
+    }
+
+    fun addCommand(command: Command) {
+        commands.add(command)
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/OutlineRightClickMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/OutlineRightClickMenu.kt
@@ -5,7 +5,6 @@ import com.badlogic.gdx.graphics.GL20
 import com.badlogic.gdx.graphics.g3d.Material
 import com.badlogic.gdx.graphics.g3d.Model
 import com.badlogic.gdx.graphics.g3d.attributes.IntAttribute
-import com.badlogic.gdx.math.Quaternion
 import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
 import com.badlogic.gdx.utils.Array
@@ -494,6 +493,7 @@ class OutlineRightClickMenu(outline: Outline) : PopupMenu() {
                     val up = Pools.vector3Pool.obtain()
                     val right = Pools.vector3Pool.obtain()
                     val q = Pools.quaternionPool.obtain()
+                    val q2 = Pools.quaternionPool.obtain()
                     val m = Pools.matrix4Pool.obtain()
 
                     // Use commands for undo/redo
@@ -525,7 +525,7 @@ class OutlineRightClickMenu(outline: Outline) : PopupMenu() {
 
                     // Calc camera's world rotation
                     val cameraWorldRot =
-                        Quaternion().setFromAxes(right.x, up.x, dir.x, right.y, up.y, dir.y, right.z, up.z, dir.z)
+                        q2.setFromAxes(right.x, up.x, dir.x, right.y, up.y, dir.y, right.z, up.z, dir.z)
 
                     // Calc parent's world rotation
                     val parentWorldRot = go.parent.getRotation(q)
@@ -545,6 +545,7 @@ class OutlineRightClickMenu(outline: Outline) : PopupMenu() {
                     Pools.vector3Pool.free(up)
                     Pools.vector3Pool.free(right)
                     Pools.quaternionPool.free(q)
+                    Pools.quaternionPool.free(q2)
                     Pools.matrix4Pool.free(m)
                 }
             })


### PR DESCRIPTION
Adds two new actions on the Outline pane for GameObjects and several minor changes.

"Align Camera to Object" - Sets the cameras position and direction, to the objects position and direction
"Align Object to Camera" - Sets the objects position and rotation to match the cameras position and direction

Align Object to Camera supports Undo/Redo.

One good use case is if you are using GameObjects to represent camera locations, either for cinematic purposes or other reasons (fixed camera style games), you can set your camera in a good spot, then align a GameObject to this spot.

Other changes:
- Added Quaternion and Matrix4 pools
- Added MultiCommand.kt, a wrapper that can execute multiple history Commands in one Undo/Redo action (Ex. Change position and rotation at same time)
- Add a fix to getRotation, always normalize axes as true, otherwise getRotation on scaled object will cause the quaternion to be affected by scaling, which we never really want

![image](https://github.com/JamesTKhan/Mundus/assets/28971753/834ba2ce-2652-4086-8703-2bf3bd159fc1)
