### PR TITLE
Allow redo/undo on GameObject active change

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/history/commands/GameObjectActiveCommand.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/history/commands/GameObjectActiveCommand.kt
@@ -1,0 +1,26 @@
+package com.mbrlabs.mundus.editor.history.commands
+
+import com.mbrlabs.mundus.commons.scene3d.GameObject
+import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.events.GameObjectModifiedEvent
+import com.mbrlabs.mundus.editor.events.SceneGraphChangedEvent
+import com.mbrlabs.mundus.editor.history.Command
+
+/**
+ * Command to change the active state of a game object.
+ * @author JamesTKhan
+ * @version August 27, 2023
+ */
+class GameObjectActiveCommand(val gameObject: GameObject, val active: Boolean) : Command {
+    override fun execute() {
+        gameObject.active = active
+        Mundus.postEvent(GameObjectModifiedEvent(gameObject))
+        Mundus.postEvent(SceneGraphChangedEvent())
+    }
+
+    override fun undo() {
+        gameObject.active = !active
+        Mundus.postEvent(GameObjectModifiedEvent(gameObject))
+        Mundus.postEvent(SceneGraphChangedEvent())
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/IdentifierWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/IdentifierWidget.kt
@@ -27,6 +27,8 @@ import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.SceneGraphChangedEvent
+import com.mbrlabs.mundus.editor.history.CommandHistory
+import com.mbrlabs.mundus.editor.history.commands.GameObjectActiveCommand
 
 /**
  * @author Marcus Brummer
@@ -39,6 +41,7 @@ class IdentifierWidget : VisTable() {
     private val tag = VisTextField("Untagged")
 
     private val projectManager: ProjectManager = Mundus.inject()
+    private val history: CommandHistory = Mundus.inject()
 
     init {
         setupUI()
@@ -67,10 +70,12 @@ class IdentifierWidget : VisTable() {
         active.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent, actor: Actor) {
                 val projectContext = projectManager.current()
-                if (projectContext.currScene.currentSelection == null) return
-                if (projectContext.currScene.currentSelection.active == active.isChecked) return
-                projectContext.currScene.currentSelection.active = active.isChecked
-                Mundus.postEvent(SceneGraphChangedEvent())
+                val go = projectContext.currScene.currentSelection ?: return
+                if (go.active == active.isChecked) return
+
+                val command = GameObjectActiveCommand(go, active.isChecked)
+                command.execute()
+                history.add(command)
             }
         })
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/OutlineRightClickMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/OutlineRightClickMenu.kt
@@ -25,6 +25,8 @@ import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.AssetImportEvent
 import com.mbrlabs.mundus.editor.events.SceneGraphChangedEvent
 import com.mbrlabs.mundus.editor.events.TerrainRemovedEvent
+import com.mbrlabs.mundus.editor.history.CommandHistory
+import com.mbrlabs.mundus.editor.history.commands.GameObjectActiveCommand
 import com.mbrlabs.mundus.editor.scene3d.components.PickableModelComponent
 import com.mbrlabs.mundus.editor.tools.ToolManager
 import com.mbrlabs.mundus.editor.ui.UI
@@ -49,6 +51,7 @@ class OutlineRightClickMenu(outline: Outline) : PopupMenu() {
     private val projectManager: ProjectManager = Mundus.inject()
     private val toolManager: ToolManager = Mundus.inject()
     private val modelImporter: ModelImporter = Mundus.inject()
+    private val history : CommandHistory = Mundus.inject()
 
 
     init {
@@ -446,8 +449,9 @@ class OutlineRightClickMenu(outline: Outline) : PopupMenu() {
 
             toggleActive.addListener(object : ClickListener() {
                 override fun clicked(event: InputEvent?, x: Float, y: Float) {
-                    currentNode!!.value.active = !currentNode!!.value.active
-                    outline.buildTree(currentNode!!.value.sceneGraph)
+                    val command = GameObjectActiveCommand(currentNode!!.value, !currentNode!!.value.active)
+                    command.execute()
+                    history.add(command)
                 }
             })
         }


### PR DESCRIPTION
Undo/Redo commands have not been kept up as good as they probably should have been. I will be making more actions undo-able as I come across them. 

When a GameObject is activated or deactivated by UI, it is now added to command history and you can redo/undo the action.