### PR TITLE
Add and use DirtyListener interface

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/DirtyListener.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/DirtyListener.java
@@ -1,0 +1,10 @@
+package com.mbrlabs.mundus.commons.scene3d;
+
+/**
+ * A listener that is notified when a GameObject is marked dirty.
+ * @author JamesTKhan
+ * @version September 17, 2023
+ */
+public interface DirtyListener {
+        void onDirty();
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/DirtyObservable.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/DirtyObservable.java
@@ -1,0 +1,30 @@
+package com.mbrlabs.mundus.commons.scene3d;
+
+import com.badlogic.gdx.utils.Array;
+
+/**
+ * Observable that notifies listeners when it is marked dirty.
+ *
+ * @author JamesTKhan
+ * @version September 17, 2023
+ */
+public class DirtyObservable {
+    private Array<DirtyListener> listeners;
+
+    public void addListener(DirtyListener listener) {
+        if (listeners == null) listeners = new Array<>();
+        listeners.add(listener);
+    }
+
+    public void removeListener(DirtyListener listener) {
+        if (listeners == null) return;
+        listeners.removeValue(listener, true);
+    }
+
+    public void notifyListeners() {
+        if (listeners == null) return;
+        for (DirtyListener listener : listeners) {
+            listener.onDirty();
+        }
+    }
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SimpleNode.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SimpleNode.java
@@ -42,12 +42,16 @@ public class SimpleNode<T extends SimpleNode> extends BaseNode<T> {
     /** Flag to indicate that the transform is dirty and needs to be recalculated */
     protected boolean isTransformDirty;
 
+    /** Observable that notifies listeners when the transform is marked dirty */
+    protected DirtyObservable dirtyObservable;
+
     public SimpleNode(int id) {
         super(id);
         localPosition = new Vector3();
         localRotation = new Quaternion();
         localScale = new Vector3(1, 1, 1);
         combined = new Matrix4();
+        dirtyObservable = new DirtyObservable();
         markDirty(); // Initialize the flag as true to ensure first calculation
     }
 
@@ -63,6 +67,7 @@ public class SimpleNode<T extends SimpleNode> extends BaseNode<T> {
         this.localRotation = new Quaternion(simpleNode.localRotation);
         this.localScale = new Vector3(simpleNode.localScale);
         this.combined = new Matrix4(simpleNode.combined);
+        this.dirtyObservable = new DirtyObservable();
         this.markDirty();  // Initialize the flag as true to ensure first calculation
     }
 
@@ -175,6 +180,8 @@ public class SimpleNode<T extends SimpleNode> extends BaseNode<T> {
 
     public void markDirty() {
         isTransformDirty = true;
+        dirtyObservable.notifyListeners();
+
         if (children == null) return;
         for (T child : children) {
             child.markDirty();
@@ -183,5 +190,13 @@ public class SimpleNode<T extends SimpleNode> extends BaseNode<T> {
 
     public boolean isDirty() {
         return isTransformDirty;
+    }
+
+    public void addDirtyListener(DirtyListener listener) {
+        dirtyObservable.addListener(listener);
+    }
+
+    public void removeDirtyListener(DirtyListener listener) {
+        dirtyObservable.removeListener(listener);
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
@@ -185,8 +185,10 @@ public abstract class CullableComponent extends AbstractComponent implements Mod
 
     @Override
     public void onDirty() {
-        orientedBoundingBox.setTransform(modelInstance.transform);
         // Force update of transform so that model instance transform is also updated
         gameObject.getTransform();
+
+        if (modelInstance == null) return;
+        orientedBoundingBox.setTransform(modelInstance.transform);
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
@@ -25,6 +25,7 @@ import com.badlogic.gdx.math.collision.OrientedBoundingBox;
 import com.badlogic.gdx.utils.Array;
 import com.mbrlabs.mundus.commons.event.Event;
 import com.mbrlabs.mundus.commons.event.EventType;
+import com.mbrlabs.mundus.commons.scene3d.DirtyListener;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.ModelCacheable;
 import com.mbrlabs.mundus.commons.scene3d.ModelEventable;
@@ -42,7 +43,7 @@ import static com.mbrlabs.mundus.commons.utils.ModelUtils.isVisible;
  * @author JamesTKhan
  * @version July 18, 2022
  */
-public abstract class CullableComponent extends AbstractComponent implements ModelEventable {
+public abstract class CullableComponent extends AbstractComponent implements ModelEventable, DirtyListener {
     private final static BoundingBox tmpBounds = new BoundingBox();
     private final static Vector3 tmpScale = new Vector3();
     private final static short frameCullCheckInterval = 15;
@@ -62,6 +63,7 @@ public abstract class CullableComponent extends AbstractComponent implements Mod
 
     public CullableComponent(GameObject go) {
         super(go);
+        go.addDirtyListener(this);
     }
 
     @Override
@@ -70,10 +72,6 @@ public abstract class CullableComponent extends AbstractComponent implements Mod
 
         if (gameObject.scaleChanged) {
             setDimensions(modelInstance);
-        }
-
-        if (gameObject.isDirty()) {
-            orientedBoundingBox.setTransform(modelInstance.transform);
         }
 
         if (!gameObject.sceneGraph.scene.settings.useFrustumCulling) {
@@ -183,5 +181,12 @@ public abstract class CullableComponent extends AbstractComponent implements Mod
 
     public boolean isCulled() {
         return isCulled;
+    }
+
+    @Override
+    public void onDirty() {
+        orientedBoundingBox.setTransform(modelInstance.transform);
+        // Force update of transform so that model instance transform is also updated
+        gameObject.getTransform();
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/LightComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/LightComponent.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.graphics.g3d.environment.BaseLight;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.mbrlabs.mundus.commons.env.lights.LightType;
+import com.mbrlabs.mundus.commons.scene3d.DirtyListener;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.utils.LightUtils;
 import net.mgsx.gltf.scene3d.lights.PointLightEx;
@@ -20,7 +21,7 @@ import net.mgsx.gltf.scene3d.lights.SpotLightEx;
  * @author JamesTKhan
  * @version May 30, 2022
  */
-public class LightComponent extends AbstractComponent {
+public class LightComponent extends AbstractComponent implements DirtyListener {
     private static final String TAG = LightComponent.class.getSimpleName();
 
     private BaseLight light;
@@ -30,6 +31,8 @@ public class LightComponent extends AbstractComponent {
 
     public LightComponent(GameObject go, LightType lightType) {
         super(go);
+        go.addDirtyListener(this);
+
         type = Type.LIGHT;
         this.lightType = lightType;
 
@@ -53,11 +56,14 @@ public class LightComponent extends AbstractComponent {
 
     @Override
     public void update(float delta) {
-        if (gameObject.isDirty()) {
-            position.set(gameObject.getPosition(tmp));
-            if (lightType == LightType.SPOT_LIGHT) {
-                ((SpotLightEx) light).direction.set(gameObject.getForwardDirection(tmp));
-            }
+        // nothing to do here
+    }
+
+    @Override
+    public void onDirty() {
+        position.set(gameObject.getPosition(tmp));
+        if (lightType == LightType.SPOT_LIGHT) {
+            ((SpotLightEx) light).direction.set(gameObject.getForwardDirection(tmp));
         }
     }
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
@@ -48,15 +48,6 @@ public class ModelComponent extends CullableComponent implements AssetUsage, Mod
     }
 
     @Override
-    public void update(float delta) {
-        super.update(delta);
-        if (gameObject.isDirty()) {
-            // Force update of transform. No need to re-assign it to modelInstance.transform
-            gameObject.getTransform();
-        }
-    }
-
-    @Override
     public RenderableProvider getRenderableProvider() {
         return modelInstance;
     }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/TerrainComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/TerrainComponent.java
@@ -47,14 +47,6 @@ public class TerrainComponent extends CullableComponent implements AssetUsage, R
     }
 
     @Override
-    public void update(float delta) {
-        super.update(delta);
-        if (gameObject.isDirty()) {
-            modelInstance.transform.set(gameObject.getTransform());
-        }
-    }
-
-    @Override
     public RenderableProvider getRenderableProvider() {
         return modelInstance;
     }

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -13,6 +13,7 @@
 - Adjustable line (selection, wireframe, helper lines) width
 - Changed UV slider to SimpleFloatSpinner in PI/16 (11.25 degree) increments
 - Counter for helper lines
+- Add DirtyObservable and DirtyListener to SimpleNode
 
 [0.5.1] ~ 08/08/2023
 - Added FPS launcher argument, always call setForegroundFPS

--- a/editor/src/main/com/mbrlabs/mundus/editor/scene3d/components/PickableLightComponent.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/scene3d/components/PickableLightComponent.java
@@ -51,12 +51,9 @@ public class PickableLightComponent extends LightComponent implements PickableCo
 
     @Override
     public void update(float delta) {
-        super.update(delta);
-        // Update position of cube for picking
-        gameObject.getPosition(tmp);
-        modelInstance.transform.setToTranslation(tmp);
-
         // Keeping this here for debugging if we need to render this cube
+        //gameObject.getPosition(tmp);
+        //modelInstance.transform.setToTranslation(tmp);
         //gameObject.sceneGraph.scene.batch.render(modelInstance, gameObject.sceneGraph.scene.environment));
     }
 
@@ -69,6 +66,8 @@ public class PickableLightComponent extends LightComponent implements PickableCo
 
     @Override
     public void renderPick() {
+        gameObject.getPosition(tmp);
+        modelInstance.transform.setToTranslation(tmp);
         gameObject.sceneGraph.scene.batch.render(modelInstance, Shaders.INSTANCE.getPickerShader());
     }
 }


### PR DESCRIPTION
Discovered while working on game jam that the current approach in components to check isDirty, is not sufficient, as it entirely depends on the order of method executions. If getTransform() is called before the update of the Component, isDirty can be false by the time the component updates. In my use case CullableComponents OrientedBoundingBox was out of sync with the actual objects position as the isDirty() check was never true.

Now instead this bullet proofs the problem by adding DirtyObservable and DirtyListener, each SimpleNode/GameObject can have listeners subscribed to a onDirty event. 

Components (as applicable) now subscribe to this event so that they can perform translation updates when the parent GameObject is dirty.