### PR TITLE
Optimization fix in Asset Clean Up system

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
@@ -75,7 +75,6 @@ public class Scene implements Disposable {
     public MundusEnvironment environment;
     public Skybox skybox;
     public String skyboxAssetId;
-    public boolean hasGLContext;
 
     public Camera cam;
     public ModelBatch batch;
@@ -97,21 +96,7 @@ public class Scene implements Disposable {
     private final Vector3 tmpCamDir = new Vector3();
     private final Vector3 tmpCamPos = new Vector3();
 
-    /**
-     * The default way to instantiate a scene. Use this constructor if you
-     * are using the runtime.
-     */
     public Scene() {
-        this(true);
-    }
-
-    /**
-     * Optionally allow instantiation of a scene without using any OpenGL context
-     * useful for when you need a scene object loaded on a different thread.
-     * @param hasGLContext normally this should be true, false if you are not on main thread
-     */
-    public Scene(boolean hasGLContext) {
-        this.hasGLContext = hasGLContext;
         environment = new MundusEnvironment();
         settings = new SceneSettings();
         modelCacheManager = new ModelCacheManager(this);
@@ -122,18 +107,16 @@ public class Scene implements Disposable {
         cam.near = CameraSettings.DEFAULT_NEAR_PLANE;
         cam.far = CameraSettings.DEFAULT_FAR_PLANE;
 
-        if (hasGLContext) {
-            dirLight = new MundusDirectionalShadowLight();
-            dirLight.color.set(LightUtils.DEFAULT_COLOR);
-            dirLight.intensity = LightUtils.DEFAULT_INTENSITY;
-            dirLight.direction.set(LightUtils.DEFAULT_DIRECTION);
-            dirLight.direction.nor();
-            environment.add(dirLight);
-            environment.set(ColorAttribute.createAmbientLight(Color.WHITE));
+        dirLight = new MundusDirectionalShadowLight();
+        dirLight.color.set(LightUtils.DEFAULT_COLOR);
+        dirLight.intensity = LightUtils.DEFAULT_INTENSITY;
+        dirLight.direction.set(LightUtils.DEFAULT_DIRECTION);
+        dirLight.direction.nor();
+        environment.add(dirLight);
+        environment.set(ColorAttribute.createAmbientLight(Color.WHITE));
 
-            initPBR();
-            setShadowQuality(ShadowResolution.DEFAULT_SHADOW_RESOLUTION);
-        }
+        initPBR();
+        setShadowQuality(ShadowResolution.DEFAULT_SHADOW_RESOLUTION);
 
         sceneGraph = new SceneGraph(this);
     }

--- a/commons/src/main/com/mbrlabs/mundus/commons/dto/AssetUsageDTO.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/dto/AssetUsageDTO.java
@@ -1,0 +1,15 @@
+package com.mbrlabs.mundus.commons.dto;
+
+import com.mbrlabs.mundus.commons.assets.Asset;
+
+import java.util.Map;
+
+/**
+ * Returns True if the DTO object uses the assetToCheck.
+ *
+ * @author JamesTKhan
+ * @version September 25, 2023
+ */
+public interface AssetUsageDTO {
+    boolean usesAsset(Asset assetToCheck, Map<String, Asset> assetMap);
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/dto/GameObjectDTO.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/dto/GameObjectDTO.java
@@ -17,12 +17,15 @@
 package com.mbrlabs.mundus.commons.dto;
 
 import com.badlogic.gdx.utils.Array;
+import com.mbrlabs.mundus.commons.assets.Asset;
+
+import java.util.Map;
 
 /**
  * @author Tibor Zsuro
  * @version 21-08-2021
  */
-public class GameObjectDTO {
+public class GameObjectDTO implements AssetUsageDTO {
 
     private int id;
     private String name;
@@ -126,5 +129,22 @@ public class GameObjectDTO {
 
     public void setCustomPropertiesComponent(final CustomPropertiesComponentDTO customPropertiesComponent) {
         this.customPropertiesComponent = customPropertiesComponent;
+    }
+
+    @Override
+    public boolean usesAsset(Asset assetToCheck, Map<String, Asset> assetMap) {
+        if (modelComponent != null && modelComponent.usesAsset(assetToCheck, assetMap)) {
+            return true;
+        }
+
+        if (terrainComponent != null && terrainComponent.usesAsset(assetToCheck, assetMap)) {
+            return true;
+        }
+
+        if (waterComponent != null && waterComponent.usesAsset(assetToCheck, assetMap)) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/dto/ModelComponentDTO.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/dto/ModelComponentDTO.java
@@ -16,13 +16,18 @@
 
 package com.mbrlabs.mundus.commons.dto;
 
+import com.mbrlabs.mundus.commons.assets.Asset;
+import com.mbrlabs.mundus.commons.assets.MaterialAsset;
+import com.mbrlabs.mundus.commons.assets.TextureAsset;
+
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Tibor Zsuro
  * @version 12-08-2021
  */
-public class ModelComponentDTO {
+public class ModelComponentDTO implements AssetUsageDTO {
 
     private String modelID;
     private HashMap<String, String> materials; // g3db material id to material asset uuid
@@ -54,5 +59,31 @@ public class ModelComponentDTO {
 
     public void setUseModelCache(boolean useModelCache) {
         this.useModelCache = useModelCache;
+    }
+
+    @Override
+    public boolean usesAsset(Asset assetToCheck, Map<String, Asset> assetMap) {
+        if (assetToCheck.getID().equals(modelID)) {
+            return true;
+        }
+
+        if (assetToCheck instanceof MaterialAsset) {
+            for (String matID : materials.keySet()) {
+                if (materials.get(matID).equals(assetToCheck.getID())) {
+                    return true;
+                }
+            }
+        }
+
+        if (assetToCheck instanceof TextureAsset) {
+            for (String matID : materials.keySet()) {
+                MaterialAsset mat = (MaterialAsset) assetMap.get(materials.get(matID));
+                if (mat != null && mat.usesAsset(assetToCheck)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/dto/TerrainComponentDTO.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/dto/TerrainComponentDTO.java
@@ -16,11 +16,16 @@
 
 package com.mbrlabs.mundus.commons.dto;
 
+import com.mbrlabs.mundus.commons.assets.Asset;
+import com.mbrlabs.mundus.commons.assets.TerrainAsset;
+
+import java.util.Map;
+
 /**
  * @author Tibor Zsuro
  * @version 12-08-2021
  */
-public class TerrainComponentDTO {
+public class TerrainComponentDTO implements AssetUsageDTO {
 
     private String terrainID;
 
@@ -32,4 +37,17 @@ public class TerrainComponentDTO {
         this.terrainID = id;
     }
 
+    @Override
+    public boolean usesAsset(Asset assetToCheck, Map<String, Asset> assetMap) {
+        if (assetToCheck.getID().equals(terrainID)) {
+            return true;
+        }
+
+        TerrainAsset terrainAsset = (TerrainAsset) assetMap.get(terrainID);
+        if (assetToCheck == terrainAsset.getMaterialAsset()){
+            return true;
+        }
+
+        return terrainAsset.usesAsset(assetToCheck);
+    }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/dto/WaterComponentDTO.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/dto/WaterComponentDTO.java
@@ -16,11 +16,15 @@
 
 package com.mbrlabs.mundus.commons.dto;
 
+import com.mbrlabs.mundus.commons.assets.Asset;
+
+import java.util.Map;
+
 /**
  * @author Tibor Zsuro
  * @version 12-08-2021
  */
-public class WaterComponentDTO {
+public class WaterComponentDTO implements AssetUsageDTO {
 
     private String waterId;
 
@@ -32,4 +36,8 @@ public class WaterComponentDTO {
         this.waterId = id;
     }
 
+    @Override
+    public boolean usesAsset(Asset assetToCheck, Map<String, Asset> assetMap) {
+        return assetToCheck.getID().equals(waterId);
+    }
 }

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -15,6 +15,7 @@
 - Counter for helper lines
 - Updated current name when renamed
 - Add DirtyObservable and DirtyListener to SimpleNode
+- Optimize AssetUsage system by using DTO objects instead of loading scene
 
 [0.5.1] ~ 08/08/2023
 - Added FPS launcher argument, always call setForegroundFPS

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -595,7 +595,6 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
                 return
             }
         } else {
-            //TODO fix
             val objectsUsingAsset = findAssetUsagesInScenes(projectManager, asset)
             val assetsUsingAsset = findAssetUsagesInAssets(asset)
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -498,26 +498,6 @@ public class ProjectManager implements Disposable {
     }
 
     /**
-     * Get all GameObjects from a scene. Partially loads the scene fast without using GL context
-     * so this can be called on a separate thread.
-     */
-    public Array<GameObject> getSceneGameObjects(ProjectContext context, String sceneName) throws FileNotFoundException {
-        SceneDTO sceneDTO = SceneManager.loadScene(context, sceneName);
-
-        Scene scene = new Scene(false);
-        for (GameObjectDTO descriptor : sceneDTO.getGameObjects()) {
-            scene.sceneGraph.addGameObject(GameObjectConverter.convert(descriptor, scene.sceneGraph, context.assetManager.getAssetMap()));
-        }
-        for (GameObject go : scene.sceneGraph.getGameObjects()) {
-            initGameObject(context, go);
-        }
-
-        scene.dispose();
-        return scene.sceneGraph.getGameObjects();
-    }
-
-
-    /**
      * Loads and opens scene
      *
      * @param projectContext

--- a/editor/src/main/com/mbrlabs/mundus/editor/scene3d/components/PickableLightComponent.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/scene3d/components/PickableLightComponent.java
@@ -32,20 +32,18 @@ public class PickableLightComponent extends LightComponent implements PickableCo
     public PickableLightComponent(GameObject go, LightType lightType) {
         super(go, lightType);
 
-        if (gameObject.sceneGraph.scene.hasGLContext) {
-            Material material = new Material();
-            material.set(new ColorAttribute(ColorAttribute.Diffuse, Color.BLUE));
+        Material material = new Material();
+        material.set(new ColorAttribute(ColorAttribute.Diffuse, Color.BLUE));
 
-            // Build simple cube as a workaround for making lights pickable
-            ModelBuilder modelBuilder = new ModelBuilder();
-            modelBuilder.begin();
-            MeshPartBuilder builder = modelBuilder.part("ID"+go.id, GL20.GL_TRIANGLES, VertexAttributes.Usage.Position | VertexAttributes.Usage.Normal, material);
-            BoxShapeBuilder.build(builder, 0,0,0, 12f, 16f, 10f);
-            Model model = modelBuilder.end();
-            modelInstance = new ModelInstance(model);
+        // Build simple cube as a workaround for making lights pickable
+        ModelBuilder modelBuilder = new ModelBuilder();
+        modelBuilder.begin();
+        MeshPartBuilder builder = modelBuilder.part("ID"+go.id, GL20.GL_TRIANGLES, VertexAttributes.Usage.Position | VertexAttributes.Usage.Normal, material);
+        BoxShapeBuilder.build(builder, 0,0,0, 12f, 16f, 10f);
+        Model model = modelBuilder.end();
+        modelInstance = new ModelInstance(model);
 
-            encodeRaypickColorId();
-        }
+        encodeRaypickColorId();
 
     }
 


### PR DESCRIPTION
I noticed during September Jam with a slightly larger project (150 assets) the Asset Clean Up was very slow, to the point of not being usable. 

This is because when I coded it, it wasn't very efficient. It loaded full Scene objects and then initialized the Scenes GameObjects (Components and all, meaning Models got instantiated and everything).

This was bad (longer than 30 seconds  on jam project). I have expanded the AssetUsage to add AssetUsageDTO. Now GameObjectDTO's can return if they use an asset or not. This is exponentially faster than the previous approach. On my jam project the search is responsive now and completes in under a second.

Also, I removed the `boolean hasGLContext` argument from Scene. This was only needed for the AssetUsage purposes to load scenes off the main thread, but was a bandaid fix.