### PR TITLE
Remove (most) rendering logic from Scene

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
@@ -59,7 +59,6 @@ public class Scene implements Disposable {
     private SceneRenderer sceneRenderer;
 
     public SceneGraph sceneGraph;
-
     public SceneSettings settings;
     public MundusEnvironment environment;
     public Skybox skybox;
@@ -172,6 +171,10 @@ public class Scene implements Disposable {
 
     public SceneRenderer getSceneRenderer() {
         return sceneRenderer;
+    }
+
+    public void setSceneRenderer(SceneRenderer sceneRenderer) {
+        this.sceneRenderer = sceneRenderer;
     }
 
     public void setDepthShader(DepthShader depthShader) {

--- a/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
@@ -16,41 +16,30 @@
 
 package com.mbrlabs.mundus.commons;
 
-import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Cubemap;
-import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
-import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g3d.ModelBatch;
 import com.badlogic.gdx.graphics.g3d.Shader;
 import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
 import com.badlogic.gdx.graphics.g3d.attributes.DirectionalLightsAttribute;
-import com.badlogic.gdx.graphics.glutils.FrameBuffer;
-import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Disposable;
 import com.mbrlabs.mundus.commons.assets.SkyboxAsset;
 import com.mbrlabs.mundus.commons.env.CameraSettings;
 import com.mbrlabs.mundus.commons.env.MundusEnvironment;
-import com.mbrlabs.mundus.commons.scene3d.GameObject;
+import com.mbrlabs.mundus.commons.rendering.DefaultSceneRenderer;
+import com.mbrlabs.mundus.commons.rendering.SceneRenderer;
 import com.mbrlabs.mundus.commons.scene3d.ModelCacheManager;
-import com.mbrlabs.mundus.commons.scene3d.ModelCacheable;
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
-import com.mbrlabs.mundus.commons.scene3d.components.Component;
-import com.mbrlabs.mundus.commons.scene3d.components.CullableComponent;
-import com.mbrlabs.mundus.commons.scene3d.components.RenderableComponent;
-import com.mbrlabs.mundus.commons.scene3d.components.WaterComponent;
 import com.mbrlabs.mundus.commons.shaders.DepthShader;
 import com.mbrlabs.mundus.commons.shadows.MundusDirectionalShadowLight;
 import com.mbrlabs.mundus.commons.shadows.ShadowResolution;
 import com.mbrlabs.mundus.commons.skybox.Skybox;
 import com.mbrlabs.mundus.commons.utils.LightUtils;
-import com.mbrlabs.mundus.commons.utils.NestableFrameBuffer;
 import com.mbrlabs.mundus.commons.water.WaterResolution;
 import net.mgsx.gltf.scene3d.attributes.PBRCubemapAttribute;
 import net.mgsx.gltf.scene3d.attributes.PBRTextureAttribute;
@@ -63,14 +52,14 @@ import net.mgsx.gltf.scene3d.utils.IBLBuilder;
 public class Scene implements Disposable {
     public static boolean isRuntime = true;
 
-    // FBO Depth Attachment index for MRT FBO
-    private static final int DEPTH_ATTACHMENT = 1;
-
-    private MundusDirectionalShadowLight dirLight;
+    public MundusDirectionalShadowLight dirLight;
     private String name;
     private long id;
 
+    private SceneRenderer sceneRenderer;
+
     public SceneGraph sceneGraph;
+
     public SceneSettings settings;
     public MundusEnvironment environment;
     public Skybox skybox;
@@ -81,25 +70,11 @@ public class Scene implements Disposable {
     public ModelBatch depthBatch;
     public ModelCacheManager modelCacheManager;
 
-    protected FrameBuffer fboWaterReflection;
-    protected FrameBuffer fboWaterRefraction;
-    protected FrameBuffer fboDepthRefraction;
-    private boolean isMRTRefraction = false;
-
-    private DepthShader depthShader;
-
-    protected Vector3 clippingPlaneDisable = new Vector3(0.0f, 0f, 0.0f);
-    protected Vector3 clippingPlaneReflection = new Vector3(0.0f, 1f, 0.0f);
-    protected Vector3 clippingPlaneRefraction = new Vector3(0.0f, -1f, 0.0f);
-
-    private final Vector3 tmpCamUp = new Vector3();
-    private final Vector3 tmpCamDir = new Vector3();
-    private final Vector3 tmpCamPos = new Vector3();
-
     public Scene() {
         environment = new MundusEnvironment();
         settings = new SceneSettings();
         modelCacheManager = new ModelCacheManager(this);
+        sceneRenderer = new DefaultSceneRenderer();
 
         cam = new PerspectiveCamera(CameraSettings.DEFAULT_FOV, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
         cam.position.set(0, 1, -3);
@@ -164,258 +139,9 @@ public class Scene implements Disposable {
      * @param delta time since last frame
      */
     public void render(float delta) {
-        renderWaterFBOs();
-        renderShadowMap();
-        renderScene(delta);
+        sceneRenderer.render(this, delta);
     }
 
-    /**
-     * Gets updated Reflection and Refraction textures for water, and captures depth for refraction if needed.
-     */
-    public void renderWaterFBOs() {
-        if (fboWaterReflection == null) {
-            Vector2 res = settings.waterResolution.getResolutionValues();
-            initFrameBuffers((int) res.x, (int) res.y);
-        }
-
-        if (sceneGraph.isContainsWater()) {
-            if (!isMRTRefraction) {
-                captureDepth();
-            }
-            captureReflectionFBO();
-            captureRefractionFBO();
-        }
-    }
-
-    /**
-     * Renders the actual 3D scene. This is called by the render method normally, but if using post-processing
-     * you may want to call this method directly.
-     * @param delta time since last frame
-     */
-    public void renderScene(float delta) {
-        modelCacheManager.update(delta);
-        batch.begin(cam);
-        renderObjects();
-        renderSkybox();
-        batch.end();
-    }
-
-    protected void renderObjects() {
-        setClippingPlane(clippingPlaneDisable, 0);
-        renderWater(sceneGraph.getRoot());
-        renderComponents(batch, sceneGraph.getRoot());
-        modelCacheManager.triggerBeforeRenderEvent();
-        batch.render(modelCacheManager.modelCache, environment);
-    }
-
-    private void setClippingPlane(Vector3 plane, float clipHeight) {
-        environment.setClippingHeight(clipHeight);
-        environment.getClippingPlane().set(plane);
-    }
-
-    /**
-     * Renders all renderable components (except Water) of the given parent game objects children
-     * recursively using default shaders.
-     *
-     * @param batch the model batch to use
-     * @param parent the parent game object
-     */
-    protected void renderComponents(ModelBatch batch, GameObject parent) {
-        renderComponents(batch, parent, null, false);
-    }
-
-    /**
-     * Renders all renderable components (except Water) of the given parent game objects children
-     * recursively.
-     *
-     * @param batch the model batch to use
-     * @param parent the parent game object
-     * @param shader the shader to use
-     * @param isDepthPass whether this is a depth render pass
-     */
-    protected void renderComponents(ModelBatch batch, GameObject parent, Shader shader, boolean isDepthPass) {
-        for (GameObject go : parent.getChildren()) {
-            if (!go.active) continue;
-            if (go.hasWaterComponent) continue;
-
-            // Render all renderable components
-            for (Component component : go.getComponents()) {
-                if (!(component instanceof RenderableComponent)) continue;
-
-                if (component instanceof CullableComponent) {
-                    CullableComponent cullableComponent = (CullableComponent) component;
-                    if (cullableComponent.isCulled()) continue;
-
-                    if (isDepthPass) {
-                        cullableComponent.triggerBeforeDepthRenderEvent();
-                    } else {
-                        cullableComponent.triggerBeforeRenderEvent();
-                    }
-                }
-
-                if (component instanceof ModelCacheable) {
-                    // Don't render the component here if it's a model cacheable
-                    ModelCacheable modelCacheable = (ModelCacheable) component;
-                    if (modelCacheable.shouldCache()) continue;
-                }
-
-                if (shader != null) {
-                    // Render the component with the given shader
-                    batch.render(((RenderableComponent) component).getRenderableProvider(), environment, shader);
-                    continue;
-                }
-
-                // Render with default shaders (Uses Provider)
-                batch.render(((RenderableComponent) component).getRenderableProvider(), environment);
-            }
-
-            // Render children recursively
-            if (go.getChildren() != null) {
-                renderComponents(batch, go, shader, isDepthPass);
-            }
-        }
-    }
-
-    /**
-     * Renders all water components of the given parent game objects children recursively.
-     * @param parent the parent game object
-     */
-    protected void renderWater(GameObject parent) {
-        if (!sceneGraph.isContainsWater()) return;
-        for (GameObject go : parent.getChildren()) {
-            if (!go.active) continue;
-
-            for (Component component : go.getComponents()) {
-                if (go.hasWaterComponent && component instanceof WaterComponent) {
-                    WaterComponent waterComponent = (WaterComponent) component;
-
-                    if (waterComponent.isCulled()) continue;
-                    waterComponent.triggerBeforeRenderEvent();
-
-                    waterComponent.getWaterAsset().setWaterReflectionTexture(getReflectionTexture());
-                    waterComponent.getWaterAsset().setWaterRefractionTexture(getRefractionTexture());
-                    waterComponent.getWaterAsset().setWaterRefractionDepthTexture(getRefractionDepthTexture());
-                    batch.render(waterComponent.getRenderableProvider(), environment);
-                }
-            }
-
-            if (go.getChildren() != null) {
-                renderWater(go);
-            }
-        }
-    }
-
-    /**
-     * Render models to the shadow map .This is called by the render method normally, but if using post-processing
-     * you may want to call this method directly.
-     */
-    public void renderShadowMap() {
-        if (dirLight == null) {
-            setShadowQuality(ShadowResolution.DEFAULT_SHADOW_RESOLUTION);
-        }
-
-        if (!dirLight.isCastsShadows()) {
-            environment.shadowMap = null;
-            return;
-        }
-
-        environment.shadowMap = dirLight;
-
-        dirLight.setCenter(cam.position);
-        dirLight.begin();
-        depthBatch.begin(dirLight.getCamera());
-        setClippingPlane(clippingPlaneDisable, 0);
-        renderComponents(depthBatch, sceneGraph.getRoot(), null, true);
-        modelCacheManager.triggerBeforeDepthRenderEvent();
-        depthBatch.render(modelCacheManager.modelCache, environment);
-        depthBatch.end();
-        dirLight.end();
-    }
-
-    protected void initFrameBuffers(int width, int height) {
-        fboWaterReflection = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
-
-        // Despite supporting MRT on WebGL2, the depth precision is far worse then doing a separate depth pass frustratingly.
-        isMRTRefraction = Gdx.graphics.isGL30Available() && Gdx.app.getType() != Application.ApplicationType.WebGL;
-
-        if (isMRTRefraction) {
-            NestableFrameBuffer.NestableFrameBufferBuilder frameBufferBuilder = new NestableFrameBuffer.NestableFrameBufferBuilder(width, height);
-            frameBufferBuilder.addBasicColorTextureAttachment(Pixmap.Format.RGB888);
-            frameBufferBuilder.addDepthTextureAttachment(GL30.GL_DEPTH_COMPONENT24, GL30.GL_UNSIGNED_INT);
-            fboWaterRefraction = frameBufferBuilder.build();
-        } else {
-            fboWaterRefraction = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
-            fboDepthRefraction = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
-        }
-    }
-
-    protected void captureReflectionFBO() {
-        if (!settings.enableWaterReflections) return;
-
-        // Calc vertical distance for camera for reflection FBO
-        float camReflectionDistance = 2 * (cam.position.y - settings.waterHeight);
-
-        // Save current cam data
-        tmpCamUp.set(cam.up);
-        tmpCamPos.set(cam.position);
-        tmpCamDir.set(cam.direction);
-
-        // Retains reflections on different camera orientations
-        cam.up.scl(-1, 1f, -1);
-        // Invert the pitch of the camera as it will be looking "up" from below current cam position
-        cam.direction.scl(1, -1, 1).nor();
-        // Position the camera below the water plane, looking "up"
-        cam.position.sub(0, camReflectionDistance, 0);
-        cam.update();
-
-        // Render reflections to FBO
-        fboWaterReflection.begin();
-        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
-        batch.begin(cam);
-        setClippingPlane(clippingPlaneReflection, -settings.waterHeight + settings.distortionEdgeCorrection);
-        renderComponents(batch, sceneGraph.getRoot());
-        batch.render(modelCacheManager.modelCache, environment);
-        renderSkybox();
-        batch.end();
-        fboWaterReflection.end();
-
-        // Restore camera data
-        cam.direction.set(tmpCamDir);
-        cam.position.set(tmpCamPos);
-        cam.up.set(tmpCamUp);
-        cam.update();
-    }
-
-    protected void captureDepth() {
-        // Render depth refractions to FBO
-        fboDepthRefraction.begin();
-        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
-        depthBatch.begin(cam);
-        setClippingPlane(clippingPlaneRefraction, settings.waterHeight + settings.distortionEdgeCorrection);
-        renderComponents(depthBatch, sceneGraph.getRoot(), depthShader, true);
-        depthBatch.render(modelCacheManager.modelCache, environment, depthShader);
-        depthBatch.end();
-        fboDepthRefraction.end();
-    }
-
-    protected void renderSkybox() {
-        if (skybox != null && skybox.active) {
-            batch.render(skybox.getSkyboxInstance(), environment, skybox.shader);
-        }
-    }
-
-    protected void captureRefractionFBO() {
-        if (!settings.enableWaterRefractions) return;
-        // Render refractions to FBO
-        fboWaterRefraction.begin();
-        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
-        batch.begin(cam);
-        setClippingPlane(clippingPlaneRefraction, settings.waterHeight + settings.distortionEdgeCorrection);
-        renderComponents(batch, sceneGraph.getRoot());
-        batch.render(modelCacheManager.modelCache, environment);
-        batch.end();
-        fboWaterRefraction.end();
-    }
 
     public String getName() {
         return name;
@@ -444,26 +170,12 @@ public class Scene implements Disposable {
         this.id = id;
     }
 
+    public SceneRenderer getSceneRenderer() {
+        return sceneRenderer;
+    }
+
     public void setDepthShader(DepthShader depthShader) {
-        this.depthShader = depthShader;
-    }
-
-    private Texture getReflectionTexture() {
-        return settings.enableWaterReflections ? fboWaterReflection.getColorBufferTexture() : null;
-    }
-
-    private Texture getRefractionTexture() {
-        return settings.enableWaterRefractions ? fboWaterRefraction.getColorBufferTexture() : null;
-    }
-
-    private Texture getRefractionDepthTexture() {
-        Texture refractionDepth;
-        if (isMRTRefraction) {
-            refractionDepth = fboWaterRefraction.getTextureAttachments().get(DEPTH_ATTACHMENT);
-        } else {
-            refractionDepth = fboDepthRefraction.getColorBufferTexture();
-        }
-        return refractionDepth;
+        sceneRenderer.setDepthShader(depthShader);
     }
 
     /**
@@ -473,8 +185,7 @@ public class Scene implements Disposable {
      */
     public void setWaterResolution(WaterResolution resolution) {
         settings.waterResolution = resolution;
-        Vector2 res = settings.waterResolution.getResolutionValues();
-        initFrameBuffers((int) res.x, (int) res.y);
+        sceneRenderer.updateWaterResolution(resolution);
     }
 
     /**
@@ -512,6 +223,11 @@ public class Scene implements Disposable {
         skybox.setRotateSpeed(skyboxAsset.rotateSpeed);
         skybox.setRotateEnabled(skyboxAsset.rotateEnabled);
 
+    }
+
+    public void setClippingPlane(Vector3 plane, float clipHeight) {
+        environment.setClippingHeight(clipHeight);
+        environment.getClippingPlane().set(plane);
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/rendering/DefaultSceneRenderer.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/rendering/DefaultSceneRenderer.java
@@ -1,0 +1,166 @@
+package com.mbrlabs.mundus.commons.rendering;
+
+import com.badlogic.gdx.graphics.g3d.ModelBatch;
+import com.badlogic.gdx.graphics.g3d.Shader;
+import com.badlogic.gdx.math.Vector3;
+import com.mbrlabs.mundus.commons.Scene;
+import com.mbrlabs.mundus.commons.scene3d.GameObject;
+import com.mbrlabs.mundus.commons.scene3d.ModelCacheable;
+import com.mbrlabs.mundus.commons.scene3d.components.Component;
+import com.mbrlabs.mundus.commons.scene3d.components.CullableComponent;
+import com.mbrlabs.mundus.commons.scene3d.components.RenderableComponent;
+import com.mbrlabs.mundus.commons.shadows.ShadowResolution;
+import com.mbrlabs.mundus.commons.water.WaterResolution;
+
+/**
+ * @author JamesTKhan
+ * @version October 03, 2023
+ */
+public class DefaultSceneRenderer implements SceneRenderer {
+    public static final Vector3 clippingPlaneDisable = new Vector3(0.0f, 0f, 0.0f);
+    private WaterRenderer waterRenderer;
+    private Shader depthShader;
+
+    public DefaultSceneRenderer() {
+        waterRenderer = new WaterRenderer();
+    }
+
+    @Override
+    public void render(Scene scene, float delta) {
+        waterRenderer.renderWaterFBOs(scene);
+        renderShadowMap(scene);
+        renderScene(scene, delta);
+    }
+
+    /**
+     * Renders the actual 3D scene. This is called by the render method normally, but if using post-processing
+     * you may want to call this method directly.
+     *
+     * @param delta time since last frame
+     */
+    public void renderScene(Scene scene, float delta) {
+        scene.modelCacheManager.update(delta);
+        scene.batch.begin(scene.cam);
+        renderObjects(scene);
+        renderSkybox(scene);
+        scene.batch.end();
+    }
+
+    protected void renderObjects(Scene scene) {
+        scene.setClippingPlane(clippingPlaneDisable, 0);
+        waterRenderer.renderWater(scene, scene.sceneGraph.getRoot());
+        renderComponents(scene, scene.batch, scene.sceneGraph.getRoot());
+        scene.modelCacheManager.triggerBeforeRenderEvent();
+        scene.batch.render(scene.modelCacheManager.modelCache, scene.environment);
+    }
+
+    /**
+     * Renders all renderable components (except Water) of the given parent game objects children
+     * recursively using default shaders.
+     *
+     * @param batch  the model batch to use
+     * @param parent the parent game object
+     */
+    public void renderComponents(Scene scene, ModelBatch batch, GameObject parent) {
+        renderComponents(scene, batch, parent, null, false);
+    }
+
+    /**
+     * Renders all renderable components (except Water) of the given parent game objects children
+     * recursively.
+     *
+     * @param batch       the model batch to use
+     * @param parent      the parent game object
+     * @param shader      the shader to use
+     * @param isDepthPass whether this is a depth render pass
+     */
+    public void renderComponents(Scene scene, ModelBatch batch, GameObject parent, Shader shader, boolean isDepthPass) {
+        for (GameObject go : parent.getChildren()) {
+            if (!go.active) continue;
+            if (go.hasWaterComponent) continue;
+
+            // Render all renderable components
+            for (Component component : go.getComponents()) {
+                if (!(component instanceof RenderableComponent)) continue;
+
+                if (component instanceof CullableComponent) {
+                    CullableComponent cullableComponent = (CullableComponent) component;
+                    if (cullableComponent.isCulled()) continue;
+
+                    if (isDepthPass) {
+                        cullableComponent.triggerBeforeDepthRenderEvent();
+                    } else {
+                        cullableComponent.triggerBeforeRenderEvent();
+                    }
+                }
+
+                if (component instanceof ModelCacheable) {
+                    // Don't render the component here if it's a model cacheable
+                    ModelCacheable modelCacheable = (ModelCacheable) component;
+                    if (modelCacheable.shouldCache()) continue;
+                }
+
+                if (shader != null) {
+                    // Render the component with the given shader
+                    batch.render(((RenderableComponent) component).getRenderableProvider(), scene.environment, shader);
+                    continue;
+                }
+
+                // Render with default shaders (Uses Provider)
+                batch.render(((RenderableComponent) component).getRenderableProvider(), scene.environment);
+            }
+
+            // Render children recursively
+            if (go.getChildren() != null) {
+                renderComponents(scene, batch, go, shader, isDepthPass);
+            }
+        }
+    }
+
+    /**
+     * Render models to the shadow map .This is called by the render method normally, but if using post-processing
+     * you may want to call this method directly.
+     */
+    public void renderShadowMap(Scene scene) {
+        if (scene.dirLight == null) {
+            scene.setShadowQuality(ShadowResolution.DEFAULT_SHADOW_RESOLUTION);
+        }
+
+        if (!scene.dirLight.isCastsShadows()) {
+            scene.environment.shadowMap = null;
+            return;
+        }
+
+        scene.environment.shadowMap = scene.dirLight;
+
+        scene.dirLight.setCenter(scene.cam.position);
+        scene.dirLight.begin();
+        scene.depthBatch.begin(scene.dirLight.getCamera());
+        scene.setClippingPlane(clippingPlaneDisable, 0);
+        renderComponents(scene, scene.depthBatch, scene.sceneGraph.getRoot(), null, true);
+        scene.modelCacheManager.triggerBeforeDepthRenderEvent();
+        scene.depthBatch.render(scene.modelCacheManager.modelCache, scene.environment);
+        scene.depthBatch.end();
+        scene.dirLight.end();
+    }
+
+    public void renderSkybox(Scene scene) {
+        if (scene.skybox != null && scene.skybox.active) {
+            scene.batch.render(scene.skybox.getSkyboxInstance(), scene.environment, scene.skybox.shader);
+        }
+    }
+
+    @Override
+    public void updateWaterResolution(WaterResolution waterResolution) {
+        waterRenderer.updateWaterResolution(waterResolution);
+    }
+
+    @Override
+    public void setDepthShader(Shader depthShader) {
+        this.depthShader = depthShader;
+    }
+
+    public Shader getDepthShader() {
+        return depthShader;
+    }
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/rendering/SceneRenderer.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/rendering/SceneRenderer.java
@@ -1,0 +1,52 @@
+package com.mbrlabs.mundus.commons.rendering;
+
+import com.badlogic.gdx.graphics.g3d.ModelBatch;
+import com.badlogic.gdx.graphics.g3d.Shader;
+import com.mbrlabs.mundus.commons.Scene;
+import com.mbrlabs.mundus.commons.scene3d.GameObject;
+import com.mbrlabs.mundus.commons.water.WaterResolution;
+
+/**
+ * Responsible for rendering a scene.
+ * @author JamesTKhan
+ * @version October 03, 2023
+ */
+public interface SceneRenderer {
+
+    /**
+     * Renders the given scene. Primary render method. If using this method
+     * you should not need to call any other render methods.
+     *
+     * @param scene the scene to render
+     * @param delta time since last frame
+     */
+    void render(Scene scene, float delta);
+
+    void renderSkybox(Scene scene);
+
+    /**
+     * Renders all renderable components (except Water) of the given parent game objects children
+     * recursively using default shaders.
+     *
+     * @param batch the model batch to use
+     * @param parent the parent game object
+     */
+    void renderComponents(Scene scene, ModelBatch batch, GameObject parent);
+
+    /**
+     * Renders all renderable components (except Water) of the given parent game objects children
+     * recursively.
+     *
+     * @param batch the model batch to use
+     * @param parent the parent game object
+     * @param shader the shader to use
+     * @param isDepthPass whether this is a depth render pass
+     */
+    void renderComponents(Scene scene, ModelBatch batch, GameObject parent, Shader shader, boolean isDepthPass);
+
+    void setDepthShader(Shader depthShader);
+
+    Shader getDepthShader();
+
+    void updateWaterResolution(WaterResolution waterResolution);
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/rendering/WaterRenderer.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/rendering/WaterRenderer.java
@@ -1,0 +1,200 @@
+package com.mbrlabs.mundus.commons.rendering;
+
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.glutils.FrameBuffer;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.math.Vector3;
+import com.mbrlabs.mundus.commons.Scene;
+import com.mbrlabs.mundus.commons.scene3d.GameObject;
+import com.mbrlabs.mundus.commons.scene3d.components.Component;
+import com.mbrlabs.mundus.commons.scene3d.components.WaterComponent;
+import com.mbrlabs.mundus.commons.utils.NestableFrameBuffer;
+import com.mbrlabs.mundus.commons.water.WaterResolution;
+
+/**
+ * @author JamesTKhan
+ * @version October 03, 2023
+ */
+public class WaterRenderer {
+
+    protected static final Vector3 clippingPlaneReflection = new Vector3(0.0f, 1f, 0.0f);
+    protected static final Vector3 clippingPlaneRefraction = new Vector3(0.0f, -1f, 0.0f);
+
+    protected FrameBuffer fboWaterReflection;
+    protected FrameBuffer fboWaterRefraction;
+    protected FrameBuffer fboDepthRefraction;
+
+    private boolean isMRTRefraction = false;
+
+    // FBO Depth Attachment index for MRT FBO
+    private static final int DEPTH_ATTACHMENT = 1;
+
+    private final Vector3 tmpCamUp = new Vector3();
+    private final Vector3 tmpCamDir = new Vector3();
+    private final Vector3 tmpCamPos = new Vector3();
+
+    /**
+     * Gets updated Reflection and Refraction textures for water, and captures depth for refraction if needed.
+     */
+    public void renderWaterFBOs(Scene scene) {
+        if (fboWaterReflection == null) {
+            Vector2 res = scene.settings.waterResolution.getResolutionValues();
+            updateFBOS((int) res.x, (int) res.y);
+        }
+
+        if (scene.sceneGraph.isContainsWater()) {
+            if (!isMRTRefraction) {
+                captureDepth(scene);
+            }
+            captureReflectionFBO(scene);
+            captureRefractionFBO(scene);
+        }
+    }
+
+    /**
+     * Renders all water components of the given parent game objects children recursively.
+     *
+     * @param parent the parent game object
+     */
+    public void renderWater(Scene scene, GameObject parent) {
+        if (!scene.sceneGraph.isContainsWater()) return;
+        for (GameObject go : parent.getChildren()) {
+            if (!go.active) continue;
+
+            for (Component component : go.getComponents()) {
+                if (go.hasWaterComponent && component instanceof WaterComponent) {
+                    WaterComponent waterComponent = (WaterComponent) component;
+
+                    if (waterComponent.isCulled()) continue;
+                    waterComponent.triggerBeforeRenderEvent();
+
+                    waterComponent.getWaterAsset().setWaterReflectionTexture(getReflectionTexture(scene));
+                    waterComponent.getWaterAsset().setWaterRefractionTexture(getRefractionTexture(scene));
+                    waterComponent.getWaterAsset().setWaterRefractionDepthTexture(getRefractionDepthTexture());
+                    scene.batch.render(waterComponent.getRenderableProvider(), scene.environment);
+                }
+            }
+
+            if (go.getChildren() != null) {
+                renderWater(scene, go);
+            }
+        }
+    }
+
+    protected void captureDepth(Scene scene) {
+        // Render depth refractions to FBO
+        fboDepthRefraction.begin();
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+        scene.depthBatch.begin(scene.cam);
+        scene.setClippingPlane(clippingPlaneRefraction, scene.settings.waterHeight + scene.settings.distortionEdgeCorrection);
+        scene.getSceneRenderer().renderComponents(scene, scene.depthBatch, scene.sceneGraph.getRoot(), scene.getSceneRenderer().getDepthShader(), true);
+        scene.depthBatch.render(scene.modelCacheManager.modelCache, scene.environment, scene.getSceneRenderer().getDepthShader());
+        scene.depthBatch.end();
+        fboDepthRefraction.end();
+    }
+
+    protected void captureRefractionFBO(Scene scene) {
+        if (!scene.settings.enableWaterRefractions) return;
+        // Render refractions to FBO
+        fboWaterRefraction.begin();
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+        scene.batch.begin(scene.cam);
+        scene.setClippingPlane(clippingPlaneRefraction, scene.settings.waterHeight + scene.settings.distortionEdgeCorrection);
+        scene.getSceneRenderer().renderComponents(scene, scene.batch, scene.sceneGraph.getRoot());
+        scene.batch.render(scene.modelCacheManager.modelCache, scene.environment);
+        scene.batch.end();
+        fboWaterRefraction.end();
+    }
+
+    protected void captureReflectionFBO(Scene scene) {
+        if (!scene.settings.enableWaterReflections) return;
+
+        // Calc vertical distance for camera for reflection FBO
+        float camReflectionDistance = 2 * (scene.cam.position.y - scene.settings.waterHeight);
+
+        // Save current cam data
+        tmpCamUp.set(scene.cam.up);
+        tmpCamPos.set(scene.cam.position);
+        tmpCamDir.set(scene.cam.direction);
+
+        // Retains reflections on different camera orientations
+        scene.cam.up.scl(-1, 1f, -1);
+        // Invert the pitch of the scene.camera as it will be looking "up" from below current cam position
+        scene.cam.direction.scl(1, -1, 1).nor();
+        // Position the scene.camera below the water plane, looking "up"
+        scene.cam.position.sub(0, camReflectionDistance, 0);
+        scene.cam.update();
+
+        // Render reflections to FBO
+        fboWaterReflection.begin();
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+        scene.batch.begin(scene.cam);
+        scene.setClippingPlane(clippingPlaneReflection, -scene.settings.waterHeight + scene.settings.distortionEdgeCorrection);
+        scene.getSceneRenderer().renderComponents(scene, scene.batch, scene.sceneGraph.getRoot());
+        scene.batch.render(scene.modelCacheManager.modelCache, scene.environment);
+        scene.getSceneRenderer().renderSkybox(scene);
+        scene.batch.end();
+        fboWaterReflection.end();
+
+        // Restore camera data
+        scene.cam.direction.set(tmpCamDir);
+        scene.cam.position.set(tmpCamPos);
+        scene.cam.up.set(tmpCamUp);
+        scene.cam.update();
+    }
+
+    protected void updateFBOS(int width, int height) {
+        if (fboWaterReflection != null) {
+            fboWaterReflection.dispose();
+        }
+        if (fboWaterRefraction != null) {
+            fboWaterRefraction.dispose();
+        }
+        if (fboDepthRefraction != null) {
+            fboDepthRefraction.dispose();
+        }
+
+        fboWaterReflection = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
+
+        // Despite supporting MRT on WebGL2, the depth precision is far worse then doing a separate depth pass frustratingly.
+        isMRTRefraction = Gdx.graphics.isGL30Available() && Gdx.app.getType() != Application.ApplicationType.WebGL;
+
+        if (isMRTRefraction) {
+            NestableFrameBuffer.NestableFrameBufferBuilder frameBufferBuilder = new NestableFrameBuffer.NestableFrameBufferBuilder(width, height);
+            frameBufferBuilder.addBasicColorTextureAttachment(Pixmap.Format.RGB888);
+            frameBufferBuilder.addDepthTextureAttachment(GL30.GL_DEPTH_COMPONENT24, GL30.GL_UNSIGNED_INT);
+            fboWaterRefraction = frameBufferBuilder.build();
+        } else {
+            fboWaterRefraction = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
+            fboDepthRefraction = new NestableFrameBuffer(Pixmap.Format.RGB888, width, height, true);
+        }
+    }
+
+    private Texture getReflectionTexture(Scene scene) {
+        return scene.settings.enableWaterReflections ? fboWaterReflection.getColorBufferTexture() : null;
+    }
+
+    private Texture getRefractionTexture(Scene scene) {
+        return scene.settings.enableWaterRefractions ? fboWaterRefraction.getColorBufferTexture() : null;
+    }
+
+    private Texture getRefractionDepthTexture() {
+        Texture refractionDepth;
+        if (isMRTRefraction) {
+            refractionDepth = fboWaterRefraction.getTextureAttachments().get(DEPTH_ATTACHMENT);
+        } else {
+            refractionDepth = fboDepthRefraction.getColorBufferTexture();
+        }
+        return refractionDepth;
+    }
+
+    public void updateWaterResolution(WaterResolution waterResolution) {
+        Vector2 res = waterResolution.getResolutionValues();
+        updateFBOS((int) res.x, (int) res.y);
+    }
+}

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -1,5 +1,6 @@
 [0.6.0] ~
 - [Breaking Change] Spotlights now use GameObjects forward direction
+- [Breaking Change] Rendering logic moved into SceneRenderer class
 - Made Scene.java more post-processing friendly for runtime users
 - Add 'getRayIntersection(Vector3, Ray)' method to TerrainComponent
 - Add rotate(yaw,pitch,roll) and setLocalRotation(yaw,pitch,roll) methods to game objects


### PR DESCRIPTION
This is another step towards removing rendering logic from Scene and putting it into its own classes. Scene is responsible for too much right now.

The rendering logic is still kinda ugly but it's at least more separate now. The reason for this is to allow more flexibility to swap out things like shadow mapping techniques in the future. Breaking change for any one calling specific render methods other than the main ones, as they are now moved into the SceneRenderer class.

This will also make it easier for Runtime users to pass in their own custom SceneRenderer to allow more control over rendering.