### PR TITLE
Deactivated terrain helper lines fix

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -18,6 +18,7 @@
 - Show mouse position on statusbar if using terrain brush tool
 - Optimize AssetUsage system by using DTO objects instead of loading scene
 - Use BufferedInputStream for faster loading of terrains
+- Fix activated/deactivated terrain at helper lines
 
 [0.5.1] ~ 08/08/2023
 - Added FPS launcher argument, always call setForegroundFPS

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HelperLines.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HelperLines.kt
@@ -21,6 +21,8 @@ import com.badlogic.gdx.math.Vector3
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
 import com.badlogic.gdx.utils.Array
 import com.badlogic.gdx.utils.Disposable
+import com.mbrlabs.mundus.commons.scene3d.components.Component
+import com.mbrlabs.mundus.editor.events.GameObjectModifiedEvent
 import com.mbrlabs.mundus.editor.events.TerrainAddedEvent
 import com.mbrlabs.mundus.editor.events.TerrainRemovedEvent
 import com.mbrlabs.mundus.editor.events.TerrainVerticesChangedEvent
@@ -28,6 +30,7 @@ import com.mbrlabs.mundus.editor.events.TerrainVerticesChangedEvent
 class HelperLines : TerrainVerticesChangedEvent.TerrainVerticesChangedEventListener,
         TerrainAddedEvent.TerrainAddedEventListener,
         TerrainRemovedEvent.TerrainRemovedEventListener,
+        GameObjectModifiedEvent.GameObjectModifiedListener,
         Disposable {
 
     private val helperLineShapes = Array<HelperLineShape>()
@@ -79,6 +82,22 @@ class HelperLines : TerrainVerticesChangedEvent.TerrainVerticesChangedEventListe
         helperLineShapes.filter { it.terrainComponent == event.terrainComponent }.forEach {
             it.dispose()
             helperLineShapes.removeValue(it, true)
+        }
+    }
+
+    override fun onGameObjectModified(event: GameObjectModifiedEvent) {
+        val go = event.gameObject ?: return
+        val terrainComponent = (go.findComponentByType(Component.Type.TERRAIN)?: return) as TerrainComponent
+
+        if (go.active) {
+            if (helperLineShapes.none { it.terrainComponent == terrainComponent }) {
+                addNewHelperLineShape(terrainComponent)
+            }
+        } else {
+            helperLineShapes.filter { it.terrainComponent == terrainComponent }.forEach {
+                it.dispose()
+                helperLineShapes.removeValue(it, true)
+            }
         }
     }
 


### PR DESCRIPTION
I've fixed that if the helper lines feature is enabled and deactivate a terrain then the helper lines of that terrain still visible.

Before fix:
![Peek 2023-10-10 17-30](https://github.com/JamesTKhan/Mundus/assets/1684274/ee0bec96-5b11-4b09-9fd6-f0cbd6896cff)

After fix:
![Peek 2023-10-10 17-27](https://github.com/JamesTKhan/Mundus/assets/1684274/d3118710-2292-4b83-8333-05f9a63acb8c)
