### PR TITLE
Two methods in scene graph where can add game object as child

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
@@ -59,7 +59,11 @@ public class SceneGraph {
     }
 
     public void addGameObject(GameObject go) {
-        root.addChild(go);
+        addGameObject(root, go);
+    }
+
+    public void addGameObject(GameObject parentGo, GameObject go) {
+        parentGo.addChild(go);
 
         if (containsWater) return;
 
@@ -81,13 +85,25 @@ public class SceneGraph {
     }
 
     /**
-     * Adds a model instance to the scene graph to the given position.
+     * Adds a model instance to the scene graph as a child of root game object.
      *
      * @param modelInstance The model instance.
      * @param position The position.
      * @return The game object of added model instance.
      */
     public GameObject addGameObject(final ModelInstance modelInstance, final Vector3 position) {
+        return addGameObject(root, modelInstance, position);
+    }
+
+    /**
+     * Adds a model instance to the scene graph as a child of parent game object.
+     *
+     * @param parentGO The parent game object.
+     * @param modelInstance The model instance.
+     * @param position The position.
+     * @return The game object of added model instance.
+     */
+    public GameObject addGameObject(final GameObject parentGO, final ModelInstance modelInstance, final Vector3 position) {
         final GameObject go = new GameObject(this, "", getNextId());
 
         go.translate(position);
@@ -102,8 +118,7 @@ public class SceneGraph {
             // this exception won't throw
         }
 
-        root.addChild(go);
-
+        addGameObject(parentGO, go);
         return go;
     }
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
@@ -74,7 +74,7 @@ public class SceneGraph {
     }
 
     /**
-     * Adds a model to the scene graph to the given position.
+     * Adds a model to the scene graph as a child of root game object.
      *
      * @param model The model.
      * @param position The position.
@@ -82,6 +82,18 @@ public class SceneGraph {
      */
     public GameObject addGameObject(final Model model, final Vector3 position) {
         return addGameObject(new ModelInstance(model), position);
+    }
+
+    /**
+     * Adds a model to the scene graph as a child of given parent game object.
+     *
+     * @param parentGO The parent game object.
+     * @param model The model.
+     * @param position The position.
+     * @return The game object of added model.
+     */
+    public GameObject addGameObject(final GameObject parentGO, final Model model, final Vector3 position) {
+        return addGameObject(parentGO, new ModelInstance(model), position);
     }
 
     /**

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -4,6 +4,7 @@
 - Made Scene.java more post-processing friendly for runtime users
 - Add 'getRayIntersection(Vector3, Ray)' method to TerrainComponent
 - Add rotate(yaw,pitch,roll) and setLocalRotation(yaw,pitch,roll) methods to game objects
+- Add 'addGameObject(GameObject, ModelInstance, Vector3)' and 'addGameObject(GameObject, Model, Vector3)' methods to SceneGraph to add external model to scene graph where can add parent game object
 
 [0.5.1] ~ 08/08/2023
 - Updated libGDX to 1.12.0


### PR DESCRIPTION
Two new methods into scene graph where can add external model/model instance to the scene graph. If call this methods then will create game objects as a child of given parent game object.

```java
addGameObject(final GameObject parentGO, final Model model, final Vector3 position)
addGameObject(final GameObject parentGO, final ModelInstance modelInstance, final Vector3 position)
```