### PR TITLE
Generic find component methods

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
@@ -148,16 +148,16 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
      *            search in node children of this game object as well?
      * @return components found
      */
-    public Array<Component> findComponentsByType(Array<Component> out, Component.Type type, boolean includeChilds) {
+    public <T extends Component> Array<T> findComponentsByType(Array<T> out, Component.Type type, boolean includeChilds) {
         if (includeChilds) {
             for (GameObject go : this) {
                 for (Component c : go.components) {
-                    if (c.getType() == type) out.add(c);
+                    if (c.getType() == type) out.add((T) c);
                 }
             }
         } else {
             for (Component c : components) {
-                if (c.getType() == type) out.add(c);
+                if (c.getType() == type) out.add((T)c);
             }
         }
 
@@ -171,11 +171,11 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
      *            component type
      * @return component if found or null
      */
-    public Component findComponentByType(Component.Type type) {
+    public <T extends Component> T findComponentByType(Component.Type type) {
         // Use regular loop, to not conflict with nested iterators
         for (int i = 0; i < components.size; i++) {
             Component c = components.get(i);
-            if (c != null && c.getType() == type) return c;
+            if (c != null && c.getType() == type) return (T) c;
         }
         return null;
     }
@@ -310,7 +310,7 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
     public void addChild(GameObject child) {
         super.addChild(child);
 
-        LightComponent component = (LightComponent) child.findComponentByType(Component.Type.LIGHT);
+        LightComponent component = child.findComponentByType(Component.Type.LIGHT);
 
         // On adding of GameObject with a Light, add it to environment
         if (component != null) {
@@ -322,7 +322,7 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
     public void remove() {
         super.remove();
 
-        LightComponent component = (LightComponent) findComponentByType(Component.Type.LIGHT);
+        LightComponent component = findComponentByType(Component.Type.LIGHT);
 
         // On removal of GameObject, remove its light component from environment
         if (component != null) {

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
@@ -24,6 +24,7 @@ import com.badlogic.gdx.utils.Array;
 import com.mbrlabs.mundus.commons.Scene;
 import com.mbrlabs.mundus.commons.scene3d.components.Component;
 import com.mbrlabs.mundus.commons.scene3d.components.ModelComponent;
+import com.mbrlabs.mundus.commons.scene3d.components.WaterComponent;
 
 /**
  * @author Marcus Brummer
@@ -67,7 +68,7 @@ public class SceneGraph {
 
         if (containsWater) return;
 
-        Component waterComponent = go.findComponentByType(Component.Type.WATER);
+        WaterComponent waterComponent = go.findComponentByType(Component.Type.WATER);
         if (waterComponent != null) {
             containsWater = true;
         }

--- a/commons/src/main/com/mbrlabs/mundus/commons/utils/ModelUtils.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/utils/ModelUtils.java
@@ -75,12 +75,12 @@ public class ModelUtils {
      * @param rootGameObject the parent game object to apply
      */
     public static void applyGameObjectMaterials(GameObject rootGameObject) {
-        ModelComponent mc = (ModelComponent) rootGameObject.findComponentByType(Component.Type.MODEL);
+        ModelComponent mc = rootGameObject.findComponentByType(Component.Type.MODEL);
         if (mc != null) {
             mc.applyMaterials();
         }
 
-        TerrainComponent tc = (TerrainComponent) rootGameObject.findComponentByType(Component.Type.TERRAIN);
+        TerrainComponent tc = rootGameObject.findComponentByType(Component.Type.TERRAIN);
         if (tc != null) {
             tc.applyMaterial();
         }

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HelperLines.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HelperLines.kt
@@ -87,7 +87,7 @@ class HelperLines : TerrainVerticesChangedEvent.TerrainVerticesChangedEventListe
 
     override fun onGameObjectModified(event: GameObjectModifiedEvent) {
         val go = event.gameObject ?: return
-        val terrainComponent = (go.findComponentByType(Component.Type.TERRAIN)?: return) as TerrainComponent
+        val terrainComponent: TerrainComponent = (go.findComponentByType(Component.Type.TERRAIN)?: return)
 
         if (go.active) {
             if (helperLineShapes.none { it.terrainComponent == terrainComponent }) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -484,14 +484,12 @@ public class ProjectManager implements Disposable {
         }
 
         // create TerrainGroup for active scene
-        Array<Component> terrainComponents = new Array<>();
+        Array<TerrainComponent> terrainComponents = new Array<>();
         for (GameObject go : sceneGraph.getGameObjects()) {
             go.findComponentsByType(terrainComponents, Component.Type.TERRAIN, true);
         }
-        for (Component c : terrainComponents) {
-            if (c instanceof TerrainComponent) {
-                scene.terrains.add(((TerrainComponent) c));
-            }
+        for (TerrainComponent c : terrainComponents) {
+            scene.terrains.add(c);
         }
 
         return scene;

--- a/editor/src/main/com/mbrlabs/mundus/editor/history/commands/DeleteCommand.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/history/commands/DeleteCommand.kt
@@ -19,6 +19,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Tree
 import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.commons.scene3d.ModelCacheManager
 import com.mbrlabs.mundus.commons.scene3d.components.Component
+import com.mbrlabs.mundus.commons.scene3d.components.LightComponent
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
@@ -78,12 +79,12 @@ class DeleteCommand(private var go: GameObject?, private var node: Outline.Outli
 
         // For components that utilize gizmos we should send a ComponentAddedEvent
         // so that GizmoManager can update as needed.
-        val lightComponent = go!!.findComponentByType(Component.Type.LIGHT)
+        val lightComponent: LightComponent? = go!!.findComponentByType(Component.Type.LIGHT)
         if (lightComponent != null) {
             Mundus.postEvent(ComponentAddedEvent(lightComponent))
         }
 
-        val terrainComponent = go!!.findComponentByType(Component.Type.TERRAIN) as TerrainComponent?
+        val terrainComponent: TerrainComponent? = go!!.findComponentByType(Component.Type.TERRAIN)
         if (terrainComponent != null) {
             projectManager.current().currScene.terrains.add(terrainComponent)
             Mundus.postEvent(TerrainAddedEvent(terrainComponent))

--- a/editor/src/main/com/mbrlabs/mundus/editor/input/FreeCamController.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/input/FreeCamController.kt
@@ -191,7 +191,7 @@ class FreeCamController(private val projectManager: ProjectManager, private val 
             var helperCell: HelperLineCenterObject? = null
 
             val go = goPicker.pick(currentScene, screenX, screenY)
-            val terrainComponent = go?.findComponentByType(Component.Type.TERRAIN) as TerrainComponent?
+            val terrainComponent: TerrainComponent? = go?.findComponentByType(Component.Type.TERRAIN)
 
             if (terrainComponent != null) {
                 val result = terrainComponent.getRayIntersection(Pools.vector3Pool.obtain(), ray)

--- a/editor/src/main/com/mbrlabs/mundus/editor/tools/SelectionTool.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/tools/SelectionTool.java
@@ -79,19 +79,19 @@ public class SelectionTool extends Tool {
             getProjectManager().getModelBatch().begin(getProjectManager().current().currScene.cam);
             for (GameObject go : getProjectManager().current().currScene.currentSelection) {
                 // model component
-                ModelComponent mc = (ModelComponent) go.findComponentByType(Component.Type.MODEL);
+                ModelComponent mc = go.findComponentByType(Component.Type.MODEL);
                 if (mc != null) {
                     getProjectManager().getModelBatch().render(mc.getModelInstance(), getShader());
                 }
 
                 // terrainAsset component
-                TerrainComponent tc = (TerrainComponent) go.findComponentByType(Component.Type.TERRAIN);
+                TerrainComponent tc = go.findComponentByType(Component.Type.TERRAIN);
                 if (tc != null) {
                     getProjectManager().getModelBatch().render(tc.getModelInstance(), getShader());
                 }
 
                 // waterAsset component
-                WaterComponent wc = (WaterComponent) go.findComponentByType(Component.Type.WATER);
+                WaterComponent wc = go.findComponentByType(Component.Type.WATER);
                 if (wc != null) {
                     getProjectManager().getModelBatch().render(wc.getWaterAsset().water, getShader());
                 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainDialog.kt
@@ -183,7 +183,7 @@ class AddTerrainDialog : BaseDialog("Add Terrain") {
                 sceneGraph.addGameObject(terrainGO)
                 terrainGO.setLocalPosition(posX, posY, posZ)
 
-                terrainComponent = terrainGO.findComponentByType(Component.Type.TERRAIN) as TerrainComponent
+                terrainComponent = terrainGO.findComponentByType(Component.Type.TERRAIN)
                 context.currScene.terrains.add(terrainComponent)
                 projectManager.current().assetManager.addNewAsset(asset)
                 Mundus.postEvent(AssetImportEvent(asset))

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/CustomPropertiesWidget.kt
@@ -44,9 +44,9 @@ class CustomPropertiesWidget(customPropertiesComponent: CustomPropertiesComponen
     }
 
     override fun setValues(go: GameObject) {
-        val c = go.findComponentByType(Component.Type.CUSTOM_PROPERTIES)
+        val c: CustomPropertiesComponent? = go.findComponentByType(Component.Type.CUSTOM_PROPERTIES)
         if (c != null) {
-            component = c as CustomPropertiesComponent
+            component = c
         }
 
         customProperties.clearChildren()

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/LightComponentWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/LightComponentWidget.kt
@@ -24,9 +24,9 @@ class LightComponentWidget(lightComponent: LightComponent) : ComponentWidget<Lig
     }
 
     override fun setValues(go: GameObject) {
-        val c = go.findComponentByType(Component.Type.LIGHT)
+        val c: LightComponent? = go.findComponentByType(Component.Type.LIGHT)
         if (c != null) {
-            component = c as LightComponent
+            component = c
         }
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/ModelComponentWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/ModelComponentWidget.kt
@@ -96,9 +96,9 @@ class ModelComponentWidget(modelComponent: ModelComponent) : ComponentWidget<Mod
     }
 
     override fun setValues(go: GameObject) {
-        val c = go.findComponentByType(Component.Type.MODEL)
+        val c: ModelComponent? = go.findComponentByType(Component.Type.MODEL)
         if (c != null) {
-            component = c as ModelComponent
+            component = c
         }
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/TransformWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/TransformWidget.kt
@@ -24,6 +24,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.kotcrab.vis.ui.widget.VisLabel
 import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.commons.scene3d.components.Component
+import com.mbrlabs.mundus.commons.scene3d.components.WaterComponent
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.history.CommandHistory
@@ -122,7 +123,7 @@ class TransformWidget : BaseInspectorWidget("Transformation") {
                 history.add(command)
 
                 // If a water component height is changed, global water height needs to update
-                if (go.findComponentByType(Component.Type.WATER) != null)
+                if (go.findComponentByType<WaterComponent?>(Component.Type.WATER) != null)
                     projectManager.current().currScene.settings.waterHeight = go.getPosition(Vector3()).y
             }
         })

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/WaterComponentWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/WaterComponentWidget.kt
@@ -43,9 +43,9 @@ class WaterComponentWidget(waterComponent: WaterComponent) :
     }
 
     override fun setValues(go: GameObject) {
-        val c = go.findComponentByType(Component.Type.WATER)
+        val c: WaterComponent? = go.findComponentByType(Component.Type.WATER)
         if (c != null) {
-            this.component = c as WaterComponent
+            this.component = c
         }
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainComponentWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainComponentWidget.kt
@@ -87,9 +87,9 @@ class TerrainComponentWidget(terrainComponent: TerrainComponent) :
     }
 
     override fun setValues(go: GameObject) {
-        val c = go.findComponentByType(Component.Type.TERRAIN)
+        val c: TerrainComponent? = go.findComponentByType(Component.Type.TERRAIN)
         if (c != null) {
-            this.component = c as TerrainComponent
+            this.component = c
         }
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
@@ -34,6 +34,7 @@ import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph
 import com.mbrlabs.mundus.commons.scene3d.components.Component
 import com.mbrlabs.mundus.commons.scene3d.components.LightComponent
+import com.mbrlabs.mundus.commons.scene3d.components.WaterComponent
 import com.mbrlabs.mundus.commons.utils.LightUtils
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.Mundus.postEvent
@@ -331,7 +332,7 @@ class Outline : VisTable(),
 
             if (containsWater) continue
 
-            val waterComponent = go.findComponentByType(Component.Type.WATER)
+            val waterComponent: WaterComponent? = go.findComponentByType(Component.Type.WATER)
             if (waterComponent != null) {
                 containsWater = true
             }
@@ -421,10 +422,8 @@ class Outline : VisTable(),
         val goCopy = GameObject(go, projectManager.current().obtainID())
 
         // Handle duplicated light components
-        val lightComponent = goCopy.findComponentByType(Component.Type.LIGHT)
+        val lightComponent: LightComponent? = goCopy.findComponentByType(Component.Type.LIGHT)
         if (lightComponent != null) {
-            lightComponent as LightComponent
-
             // Remove the duplicated light component
             goCopy.removeComponent(lightComponent)
             lightComponent.remove()

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/OutlineRightClickMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/OutlineRightClickMenu.kt
@@ -18,6 +18,7 @@ import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph
 import com.mbrlabs.mundus.commons.scene3d.components.Component
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
+import com.mbrlabs.mundus.commons.scene3d.components.WaterComponent
 import com.mbrlabs.mundus.commons.utils.Pools
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.assets.MetaSaver
@@ -109,7 +110,7 @@ class OutlineRightClickMenu(outline: Outline) : PopupMenu() {
                         toolManager.setDefaultTool()
                     }
 
-                    val terrainComponent = selectedGO!!.findComponentByType(Component.Type.TERRAIN) as TerrainComponent?
+                    val terrainComponent: TerrainComponent? = selectedGO!!.findComponentByType(Component.Type.TERRAIN)
                     if (terrainComponent != null) {
                         projectManager.current().currScene.terrains.removeValue(terrainComponent, true)
                         Mundus.postEvent(TerrainRemovedEvent(terrainComponent))
@@ -155,8 +156,8 @@ class OutlineRightClickMenu(outline: Outline) : PopupMenu() {
 
         // some assets can not be duplicated
         duplicate.isDisabled = selectedGO == null
-                || selectedGO!!.findComponentByType(Component.Type.TERRAIN) != null
-                || selectedGO!!.findComponentByType(Component.Type.WATER) != null
+                || selectedGO!!.findComponentByType<TerrainComponent?>(Component.Type.TERRAIN) != null
+                || selectedGO!!.findComponentByType<WaterComponent?>(Component.Type.WATER) != null
     }
 
     fun showRenameDialog() {

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -5,6 +5,7 @@
 - Add 'getRayIntersection(Vector3, Ray)' method to TerrainComponent
 - Add rotate(yaw,pitch,roll) and setLocalRotation(yaw,pitch,roll) methods to game objects
 - Add 'addGameObject(GameObject, ModelInstance, Vector3)' and 'addGameObject(GameObject, Model, Vector3)' methods to SceneGraph to add external model to scene graph where can add parent game object
+- Generic findComponentsByType and findComponentByType methods
 
 [0.5.1] ~ 08/08/2023
 - Updated libGDX to 1.12.0


### PR DESCRIPTION
Changed GameObject's **findComponentsByType** and **findComponentByType** methods from
```java
Array<Component> findComponentsByType(Array<Component>, Component.Type, boolean)
Component findComponentByType(Component.Type)
```
to
```java
<T extends Component> Array<T> findComponentsByType(Array<T>, Component.Type, boolean)
<T extends Component> T findComponentByType(Component.Type)
```

so can call these methods 
```java
Array<ModelComponent> components = gameObject.findComponentsByType(new Array<ModelComponent>(), Component.Type.MODEL, true)
ModelComponent component = gameObject.findComponentByType(Component.Type.MODEL)
```
instead of 
```java
Array<Component> components = gameObject.findComponentsByType(new Array<Component>(), Component.Type.MODEL, true)
ModelComponent component = (ModelComponent) gameObject.findComponentByType(Component.Type.MODEL)
```

I've tested on HTML, and it works.
