### PR TITLE
Add water and terrain as child game object

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
@@ -144,24 +144,12 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
      *            output array
      * @param type
      *            component type
-     * @param includeChilds
-     *            search in node children of this game object as well?
+     * @param recursive
+     *            recursive search?
      * @return components found
      */
-    public Array<Component> findComponentsByType(Array<Component> out, Component.Type type, boolean includeChilds) {
-        if (includeChilds) {
-            for (GameObject go : this) {
-                for (Component c : go.components) {
-                    if (c.getType() == type) out.add(c);
-                }
-            }
-        } else {
-            for (Component c : components) {
-                if (c.getType() == type) out.add(c);
-            }
-        }
-
-        return out;
+    public Array<Component> findComponentsByType(Array<Component> out, Component.Type type, boolean recursive) {
+        return findComponentsByType(out, this, type, recursive);
     }
 
     /**
@@ -389,6 +377,22 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
             child.scaleChanged = true;
             updateChildrenScaleChanged(child);
         }
+    }
+
+    private Array<Component> findComponentsByType(Array<Component> out, GameObject go, Component.Type type, boolean recursive) {
+        for (int i = 0; i < go.components.size; ++i) {
+            Component c = go.components.get(i);
+            if (c.getType() == type) out.add(c);
+        }
+
+        if (recursive && go.children != null) {
+            for (int i = 0; i < go.children.size; ++i) {
+                GameObject child = go.children.get(i);
+                findComponentsByType(out, child, type, true);
+            }
+        }
+
+        return out;
     }
 
 }

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -19,6 +19,7 @@
 - Optimize AssetUsage system by using DTO objects instead of loading scene
 - Use BufferedInputStream for faster loading of terrains
 - Fix activated/deactivated terrain at helper lines
+- Fix add water and terrain as child
 
 [0.5.1] ~ 08/08/2023
 - Added FPS launcher argument, always call setForegroundFPS

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainDialog.kt
@@ -25,6 +25,7 @@ import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
 import com.kotcrab.vis.ui.widget.VisTextField
 import com.mbrlabs.mundus.commons.assets.TerrainAsset
+import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.commons.scene3d.components.Component
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
 import com.mbrlabs.mundus.commons.terrain.SplatMapResolution
@@ -66,6 +67,8 @@ class AddTerrainDialog : BaseDialog("Add Terrain") {
     private var projectManager : ProjectManager
     private var ioManager : IOManager
 
+    private var selectedGO : GameObject? = null
+
     init {
         isResizable = true
         projectManager = Mundus.inject()
@@ -73,6 +76,11 @@ class AddTerrainDialog : BaseDialog("Add Terrain") {
         setupUI()
         setDefaults()
         setupListeners()
+    }
+
+    fun show(selectedGO: GameObject?) {
+        this.selectedGO = selectedGO
+        UI.showDialog(this)
     }
 
     private fun setDefaults() {
@@ -180,11 +188,10 @@ class AddTerrainDialog : BaseDialog("Add Terrain") {
 
                 val terrainGO = createTerrainGO(sceneGraph, goID, terrainName, asset)
                 // update sceneGraph
-                val parentGO = UI.outline.getSelectedGameObject()
-                if (parentGO == null) {
+                if (selectedGO == null) {
                     sceneGraph.addGameObject(terrainGO)
                 } else {
-                    sceneGraph.addGameObject(parentGO, terrainGO)
+                    sceneGraph.addGameObject(selectedGO, terrainGO)
                 }
                 terrainGO.setLocalPosition(posX, posY, posZ)
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainDialog.kt
@@ -180,7 +180,12 @@ class AddTerrainDialog : BaseDialog("Add Terrain") {
 
                 val terrainGO = createTerrainGO(sceneGraph, goID, terrainName, asset)
                 // update sceneGraph
-                sceneGraph.addGameObject(terrainGO)
+                val parentGO = UI.outline.getSelectedGameObject()
+                if (parentGO == null) {
+                    sceneGraph.addGameObject(terrainGO)
+                } else {
+                    sceneGraph.addGameObject(parentGO, terrainGO)
+                }
                 terrainGO.setLocalPosition(posX, posY, posZ)
 
                 terrainComponent = terrainGO.findComponentByType(Component.Type.TERRAIN) as TerrainComponent

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddWaterDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddWaterDialog.kt
@@ -9,6 +9,7 @@ import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
 import com.kotcrab.vis.ui.widget.VisTextField
 import com.mbrlabs.mundus.commons.assets.WaterAsset
+import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.commons.water.Water
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.assets.AssetAlreadyExistsException
@@ -41,6 +42,8 @@ class AddWaterDialog : BaseDialog("Add Water") {
     private var projectManager : ProjectManager
     private var ioManager : IOManager
 
+    private var selectedGO : GameObject? = null
+
     init {
         isResizable = true
 
@@ -50,6 +53,11 @@ class AddWaterDialog : BaseDialog("Add Water") {
         setupUI()
         setDefaults()
         setupListeners()
+    }
+
+    fun show(selectedGO: GameObject?) {
+        this.selectedGO = selectedGO
+        UI.showDialog(this)
     }
 
     private fun setupUI() {
@@ -124,11 +132,10 @@ class AddWaterDialog : BaseDialog("Add Water") {
                 val waterGO = createWaterGO(sceneGraph,
                         null, goID, waterName, asset)
                 // update sceneGraph
-                val parentGO = UI.outline.getSelectedGameObject()
-                if (parentGO == null) {
+                if (selectedGO == null) {
                     sceneGraph.addGameObject(waterGO)
                 } else {
-                    sceneGraph.addGameObject(parentGO, waterGO)
+                    sceneGraph.addGameObject(selectedGO, waterGO)
                 }
                 waterGO.setLocalPosition(posX, posY, posZ)
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddWaterDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddWaterDialog.kt
@@ -17,6 +17,7 @@ import com.mbrlabs.mundus.editor.core.io.IOManagerProvider
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.AssetImportEvent
 import com.mbrlabs.mundus.editor.events.SceneGraphChangedEvent
+import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.widgets.FloatFieldWithLabel
 import com.mbrlabs.mundus.editor.ui.widgets.IntegerFieldWithLabel
 import com.mbrlabs.mundus.editor.ui.widgets.ToolTipLabel
@@ -123,7 +124,12 @@ class AddWaterDialog : BaseDialog("Add Water") {
                 val waterGO = createWaterGO(sceneGraph,
                         null, goID, waterName, asset)
                 // update sceneGraph
-                sceneGraph.addGameObject(waterGO)
+                val parentGO = UI.outline.getSelectedGameObject()
+                if (parentGO == null) {
+                    sceneGraph.addGameObject(waterGO)
+                } else {
+                    sceneGraph.addGameObject(parentGO, waterGO)
+                }
                 waterGO.setLocalPosition(posX, posY, posZ)
 
                 Mundus.postEvent(SceneGraphChangedEvent())

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
@@ -331,8 +331,8 @@ class Outline : VisTable(),
 
             if (containsWater) continue
 
-            val waterComponent = go.findComponentByType(Component.Type.WATER)
-            if (waterComponent != null) {
+            val waterComponents = go.findComponentsByType(Array(), Component.Type.WATER, true)
+            if (waterComponents.notEmpty()) {
                 containsWater = true
             }
         }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/OutlineRightClickMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/OutlineRightClickMenu.kt
@@ -376,14 +376,14 @@ class OutlineRightClickMenu(outline: Outline) : PopupMenu() {
             // add terrainAsset
             addTerrain.addListener(object : ClickListener() {
                 override fun clicked(event: InputEvent?, x: Float, y: Float) {
-                    UI.showDialog(UI.addTerrainDialog)
+                    UI.addTerrainDialog.show(selectedGO)
                 }
             })
 
             // add waterAsset
             addWater.addListener(object : ClickListener() {
                 override fun clicked(event: InputEvent?, x: Float, y: Float) {
-                    UI.showDialog(UI.addWaterDialog)
+                    UI.addWaterDialog.show(selectedGO)
                 }
             })
         }

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -6,6 +6,7 @@
 - Add 'getRayIntersection(Vector3, Ray)' method to TerrainComponent
 - Add rotate(yaw,pitch,roll) and setLocalRotation(yaw,pitch,roll) methods to game objects
 - Add 'addGameObject(GameObject, ModelInstance, Vector3)' and 'addGameObject(GameObject, Model, Vector3)' methods to SceneGraph to add external model to scene graph where can add parent game object
+- Fix render water if it is child game object
 
 [0.5.1] ~ 08/08/2023
 - Updated libGDX to 1.12.0

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -1,7 +1,7 @@
 [0.6.0] ~
 - [Breaking Change] Spotlights now use GameObjects forward direction
 - [Breaking Change] Rendering logic moved into SceneRenderer class
-- [Breaking Change] findComponentsByType(Array, Component.Type, boolean) method in GameObject find in the current game object too and if the boolean is true then search recursively not just only in children
+- [Breaking Change] findComponentsByType(Array, Component.Type, boolean) method in GameObject find in the current game object too and if the boolean is true then search recursively not just in children
 - Made Scene.java more post-processing friendly for runtime users
 - Add 'getRayIntersection(Vector3, Ray)' method to TerrainComponent
 - Add rotate(yaw,pitch,roll) and setLocalRotation(yaw,pitch,roll) methods to game objects

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -1,6 +1,7 @@
 [0.6.0] ~
 - [Breaking Change] Spotlights now use GameObjects forward direction
 - [Breaking Change] Rendering logic moved into SceneRenderer class
+- [Breaking Change] findComponentsByType(Array, Component.Type, boolean) method in GameObject find in the current game object too and if the boolean is true then search recursively not just only in children
 - Made Scene.java more post-processing friendly for runtime users
 - Add 'getRayIntersection(Vector3, Ray)' method to TerrainComponent
 - Add rotate(yaw,pitch,roll) and setLocalRotation(yaw,pitch,roll) methods to game objects

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/SceneConverter.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/SceneConverter.java
@@ -18,6 +18,7 @@ package com.mbrlabs.mundus.runtime.converter;
 
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
+import com.badlogic.gdx.utils.Array;
 import com.mbrlabs.mundus.commons.Scene;
 import com.mbrlabs.mundus.commons.assets.AssetManager;
 import com.mbrlabs.mundus.commons.dto.GameObjectDTO;
@@ -26,7 +27,9 @@ import com.mbrlabs.mundus.commons.env.CameraSettings;
 import com.mbrlabs.mundus.commons.mapper.BaseLightConverter;
 import com.mbrlabs.mundus.commons.mapper.DirectionalLightConverter;
 import com.mbrlabs.mundus.commons.mapper.FogConverter;
+import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
+import com.mbrlabs.mundus.commons.scene3d.components.Component;
 import com.mbrlabs.mundus.commons.shadows.MundusDirectionalShadowLight;
 import com.mbrlabs.mundus.commons.water.WaterResolution;
 import com.mbrlabs.mundus.runtime.Shaders;
@@ -73,6 +76,7 @@ public class SceneConverter {
         scene.sceneGraph = new SceneGraph(scene);
         for (GameObjectDTO descriptor : dto.getGameObjects()) {
             scene.sceneGraph.addGameObject(GameObjectConverter.convert(descriptor, scene.sceneGraph, shaders, assetManager));
+            scene.sceneGraph.setContainsWater(containsWaterComponent(scene.sceneGraph.getRoot()));
         }
 
         // Set cam settings
@@ -84,5 +88,22 @@ public class SceneConverter {
         scene.cam.update();
 
         return scene;
+    }
+
+    /**
+     * Checks recursively that given game object contains water component or not.
+     */
+    private static boolean containsWaterComponent(final GameObject go) {
+        final Array<GameObject> children = go.getChildren();
+        if (go.hasWaterComponent) {
+            return true;
+        } else if (children != null && children.notEmpty()) {
+            for (int i = 0; i < children.size; ++i) {
+                final boolean hasWaterComponent = containsWaterComponent(children.get(i));
+                if (hasWaterComponent) return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
This PR contains some fixes:

1) If we move the mouse to a game object in Outline and click to Add water or Add terrain then it will be added as child game object.

2) If we create a water at root in Outline and move it into a game object as a child game object then it will be rendered.

3) There is the `findComponentsByType(Array<Component> out, Component.Type type, boolean includeChilds)` method in GameObject class and it's javadoc says that if the **includeChilds** variable is true then it searches in children too, but in this case this method doesn't search in the current game object, only in children. So with this fixes if **recursive** variable is true then it will search in the current game object and recursively too. Added this changes into runtime's CHANGES file as braking changes.

4) Rendering water in runtime if water is child object.
