### PR TITLE
Terrain activation if helper lines disabled fix

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HelperLines.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/helperlines/HelperLines.kt
@@ -90,7 +90,7 @@ class HelperLines : TerrainVerticesChangedEvent.TerrainVerticesChangedEventListe
         val terrainComponent = (go.findComponentByType(Component.Type.TERRAIN)?: return) as TerrainComponent
 
         if (go.active) {
-            if (helperLineShapes.none { it.terrainComponent == terrainComponent }) {
+            if (type != null && helperLineShapes.none { it.terrainComponent == terrainComponent }) {
                 addNewHelperLineShape(terrainComponent)
             }
         } else {


### PR DESCRIPTION
Currently if helper lines is not enabled and activate a deactivated terrain then there is an exception.

```java
Caused by: java.lang.IllegalArgumentException: Step must be positive, was: -1.
	at kotlin.ranges.RangesKt__RangesKt.checkStepIsPositive(Ranges.kt:274)
	at kotlin.ranges.RangesKt___RangesKt.step(_Ranges.kt:966)
	at com.mbrlabs.mundus.editor.core.helperlines.HexagonHelperLineShape.calculate(HexagonHelperLineShape.kt:137)
	at com.mbrlabs.mundus.editor.core.helperlines.HexagonHelperLineShape.calculateIndicesNum(HexagonHelperLineShape.kt:44)
	at com.mbrlabs.mundus.editor.core.helperlines.HelperLineShape.<init>(HelperLineShape.kt:66)
	at com.mbrlabs.mundus.editor.core.helperlines.HexagonHelperLineShape.<init>(HexagonHelperLineShape.kt:27)
	at com.mbrlabs.mundus.editor.core.helperlines.HelperLines.addNewHelperLineShape(HelperLines.kt:115)
	at com.mbrlabs.mundus.editor.core.helperlines.HelperLines.onGameObjectModified(HelperLines.kt:94)
	... 19 more
```