### PR TITLE
Game object children sorting action menu

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -19,6 +19,7 @@
 - Optimize AssetUsage system by using DTO objects instead of loading scene
 - Use BufferedInputStream for faster loading of terrains
 - Fix activated/deactivated terrain at helper lines
+- Sort children action command in Outline
 
 [0.5.1] ~ 08/08/2023
 - Added FPS launcher argument, always call setForegroundFPS

--- a/editor/src/main/com/mbrlabs/mundus/editor/history/commands/SortChildrenCommand.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/history/commands/SortChildrenCommand.kt
@@ -1,0 +1,34 @@
+package com.mbrlabs.mundus.editor.history.commands
+
+import com.badlogic.gdx.utils.Array
+import com.mbrlabs.mundus.commons.scene3d.GameObject
+import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.events.SceneGraphChangedEvent
+import com.mbrlabs.mundus.editor.history.Command
+
+class SortChildrenCommand(private val childArray: Array<GameObject>) : Command {
+
+    private val originalSorting = Array<Int>()
+
+    init {
+        childArray.forEach { originalSorting.add(it.id) }
+    }
+
+    override fun execute() {
+        childArray.sort(GameObjectExecuteComparator())
+        Mundus.postEvent(SceneGraphChangedEvent())
+    }
+
+    override fun undo() {
+        childArray.sort(GameObjectUndoComparator(originalSorting))
+        Mundus.postEvent(SceneGraphChangedEvent())
+    }
+
+    inner class GameObjectExecuteComparator : Comparator<GameObject> {
+        override fun compare(left: GameObject, right: GameObject): Int = left.name.compareTo(right.name)
+    }
+
+    inner class GameObjectUndoComparator(private val originalSorting: Array<Int>) : Comparator<GameObject> {
+        override fun compare(left: GameObject, right: GameObject): Int = originalSorting.indexOf(left.id) - originalSorting.indexOf(right.id)
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/OutlineRightClickMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/OutlineRightClickMenu.kt
@@ -33,6 +33,7 @@ import com.mbrlabs.mundus.editor.history.commands.MultiCommand
 import com.mbrlabs.mundus.editor.history.commands.RotateCommand
 import com.mbrlabs.mundus.editor.history.commands.TranslateCommand
 import com.mbrlabs.mundus.editor.history.commands.GameObjectActiveCommand
+import com.mbrlabs.mundus.editor.history.commands.SortChildrenCommand
 import com.mbrlabs.mundus.editor.scene3d.components.PickableModelComponent
 import com.mbrlabs.mundus.editor.tools.ToolManager
 import com.mbrlabs.mundus.editor.ui.UI
@@ -452,14 +453,16 @@ class OutlineRightClickMenu(outline: Outline) : PopupMenu() {
      * A submenu to allow adding GameObjects to the scene
      */
     private inner class ActionSubMenu : PopupMenu() {
-        private val toggleActive: MenuItem = MenuItem("Toggle active")
-        private val alignCameraToObject: MenuItem = MenuItem("Align Camera to Object")
-        private val alignObjectToCamera: MenuItem = MenuItem("Align Object to Camera")
+        private val toggleActive = MenuItem("Toggle active")
+        private val alignCameraToObject = MenuItem("Align Camera to Object")
+        private val alignObjectToCamera = MenuItem("Align Object to Camera")
+        private val sortChildren = MenuItem("Sort children")
 
         init {
             addItem(toggleActive)
             addItem(alignCameraToObject)
             addItem(alignObjectToCamera)
+            addItem(sortChildren)
 
             toggleActive.addListener(object : ClickListener() {
                 override fun clicked(event: InputEvent?, x: Float, y: Float) {
@@ -555,6 +558,17 @@ class OutlineRightClickMenu(outline: Outline) : PopupMenu() {
                     Pools.matrix4Pool.free(m)
                 }
             })
+
+            sortChildren.addListener(object: ClickListener() {
+                override fun clicked(event: InputEvent?, x: Float, y: Float) {
+                    val childArray = getChildArray()
+
+                    val command = SortChildrenCommand(childArray)
+                    command.execute()
+
+                    history.add(command)
+                }
+            })
         }
 
         fun show() {
@@ -570,6 +584,14 @@ class OutlineRightClickMenu(outline: Outline) : PopupMenu() {
             } else {
                 toggleActive.text = "Activate"
             }
+
+            sortChildren.isDisabled = getChildrenNum() == 0
+        }
+
+        fun getChildrenNum(): Int = currentNode!!.value.children?.size ?: 0
+
+        fun getChildArray(): Array<GameObject> {
+            return currentNode!!.value.children
         }
 
     }


### PR DESCRIPTION
If a game object has children then the Sort children menu enabled and it sorts the children alphabetically.

![image](https://github.com/JamesTKhan/Mundus/assets/1684274/4d5f754d-4559-4fd0-819d-9a18ef652ac5)
