### PR TITLE
Disable button on camera movement speed selection (#263)

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/input/FreeCamController.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/input/FreeCamController.kt
@@ -87,6 +87,16 @@ class FreeCamController(private val projectManager: ProjectManager, private val 
     }
 
     /**
+     * Returns the velocity in units per second for moving forward, backward and
+     * strafing left/right.
+     *
+     * @return the current velocity
+     */
+    fun getVelocity(): Float {
+        return this.velocity
+    }
+
+    /**
      * Sets how many degrees to rotate per pixel the mouse moved.
      *
      * @param degreesPerPixel

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/StatusBar.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/StatusBar.kt
@@ -84,24 +84,53 @@ class StatusBar : VisTable() {
         right.add(fpsLabel).right()
 
         setupListeners()
+        handleCameraMovementSpeedChange()
+    }
+
+    /**
+     * Disables the button corresponding to the currently
+     * selected camera movement speed.
+     */
+    private fun handleCameraMovementSpeedChange() {
+        val cameraMovementSpeed: Float = freeCamController.getVelocity()
+
+        speed01.isDisabled = false
+        speed1.isDisabled = false
+        speed10.isDisabled = false
+
+        when (cameraMovementSpeed) {
+            freeCamController.SPEED_01 -> speed01.isDisabled = true
+            freeCamController.SPEED_1 -> speed1.isDisabled = true
+            freeCamController.SPEED_10 -> speed10.isDisabled = true
+        }
+    }
+
+    /**
+     * Set movement speed of the camera.
+     *
+     * @param movementSpeed the new speed of camera movement
+     */
+    private fun setCameraMovementSpeed(movementSpeed: Float) {
+        freeCamController.setVelocity(movementSpeed)
+        handleCameraMovementSpeedChange()
     }
 
     fun setupListeners() {
         speed01.addListener(object : ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
-                freeCamController.setVelocity(freeCamController.SPEED_01)
+               setCameraMovementSpeed(freeCamController.SPEED_01)
             }
         })
 
         speed1.addListener(object : ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
-                freeCamController.setVelocity(freeCamController.SPEED_1)
+                setCameraMovementSpeed(freeCamController.SPEED_1)
             }
         })
 
         speed10.addListener(object : ClickListener() {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
-                freeCamController.setVelocity(freeCamController.SPEED_10)
+                setCameraMovementSpeed(freeCamController.SPEED_10)
             }
         })
     }


### PR DESCRIPTION
Not sure if this counts but I think it can serve as a basic indicator for the selected movement speed. It also guides the user because only valid options remain clickable.

[Screencast from 2023-11-10 18-01-50.webm](https://github.com/JamesTKhan/Mundus/assets/150134091/b975775b-3ac9-49c6-92e0-f0e068755fb1)
