### PR TITLE
Handle asset import errors

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -895,6 +895,9 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
     }
 
     private fun copyToAssetFolder(file: FileHandle): FileHandle {
+        if (FilenameUtils.directoryContains(rootFolder.path(), file.path())) {
+            return file
+        }
         val copy = FileHandle(FilenameUtils.concat(rootFolder.path(), file.name()))
         file.copyTo(copy)
         return copy

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -375,13 +375,18 @@ public class ProjectManager implements Disposable {
     }
 
     public ProjectContext continueLoading() throws FileNotFoundException, MetaFileParseException, AssetNotFoundException {
-        boolean complete = loadingProject.assetManager.continueLoading();
+        try {
+            boolean complete = loadingProject.assetManager.continueLoading();
 
-        if (!complete) {
-            return loadingProject;
+            if (!complete) {
+                return loadingProject;
+            }
+
+            return finalizeLoading();
+        } catch (GdxRuntimeException exception) {
+            UI.INSTANCE.getToaster().error(exception.getCause().getMessage());
+            return finalizeLoading();
         }
-
-        return finalizeLoading();
     }
 
     private ProjectContext finalizeLoading() throws FileNotFoundException {


### PR DESCRIPTION
The main problem i found should be solved, but in case something goes wrong the user at least gets a notification.

![screenshot error message](https://github.com/JamesTKhan/Mundus/assets/150134091/15cc48ac-4c31-4933-b7b8-0adcdb93f510)

Unfortunately when loading goes wrong there are no asset visible in the ui even though the editor does not crash any more. At least the user gets a hint on how to fix the issue.