### PR TITLE
Fix crash when using libgdx-screenmanager library

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/shadows/MundusDirectionalShadowLight.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shadows/MundusDirectionalShadowLight.java
@@ -62,12 +62,7 @@ public class MundusDirectionalShadowLight extends DirectionalShadowLight {
         }
 
         Vector2 res = shadowResolution.getResolutionValues();
-
-        if (Scene.isRuntime) {
-            fbo = new FrameBuffer(Pixmap.Format.RGBA8888, (int) res.x, (int) res.y, true);
-        } else {
-            fbo = new NestableFrameBuffer(Pixmap.Format.RGBA8888, (int) res.x, (int) res.y, true);
-        }
+        fbo = new NestableFrameBuffer(Pixmap.Format.RGBA8888, (int) res.x, (int) res.y, true);
     }
 
     public boolean isCastsShadows() {


### PR DESCRIPTION
Fixes a crash with using libGDX-screenmanager library by using NestableFrameBuffer for our ShadowMap all the time, as Screenmanager requires the applications to use NestableFrameBuffer instead of FrameBuffer.