### PR TITLE
Model thumbnail in Assets Dock

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/AssetManager.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/AssetManager.java
@@ -437,7 +437,7 @@ public class AssetManager implements Disposable {
         return asset;
     }
 
-    private ModelAsset loadModelAsset(Meta meta, FileHandle assetFile) {
+    protected ModelAsset loadModelAsset(Meta meta, FileHandle assetFile) {
         ModelAsset asset = new ModelAsset(meta, assetFile);
         asset.load(gdxAssetManager);
         return asset;

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -21,6 +21,7 @@
 - Fix activated/deactivated terrain at helper lines
 - Sort children action command in Outline
 - Fix add water and terrain as child
+- Thumbnail view for model asset in Asset Dock
 
 [0.5.1] ~ 08/08/2023
 - Added FPS launcher argument, always call setForegroundFPS

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -269,8 +269,9 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
 
         // load & return asset
         val assetFile = FileHandle(FilenameUtils.concat(rootFolder.path(), modelFilename))
-        val asset = ModelAsset(meta, assetFile)
+        val asset = EditorModelAsset(meta, assetFile)
         asset.load()
+        asset.thumbnail = ThumbnailGenerator.generateThumbnail(asset.model)
 
         addAsset(asset)
         return asset

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -51,6 +51,7 @@ import com.mbrlabs.mundus.editor.events.LogEvent
 import com.mbrlabs.mundus.editor.events.LogType
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.utils.Log
+import com.mbrlabs.mundus.editor.utils.ThumbnailGenerator
 import net.mgsx.gltf.exporters.GLTFExporter
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.FilenameUtils
@@ -965,6 +966,13 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
         // Save to file
         val fileHandle = FileHandle(path)
         fileHandle.writeString(moreDetails, false)
+    }
+
+    override fun loadModelAsset(meta: Meta, assetFile: FileHandle): ModelAsset {
+        val asset = EditorModelAsset(meta, assetFile);
+        asset.load(gdxAssetManager)
+        asset.thumbnail = ThumbnailGenerator.generateThumbnail(asset.model)
+        return asset
     }
 
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorModelAsset.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorModelAsset.kt
@@ -27,4 +27,9 @@ class EditorModelAsset(meta: Meta, assetFile: FileHandle) : ModelAsset(meta, ass
     lateinit var thumbnail: Texture
     override fun getTexture(): Texture = thumbnail
 
+    override fun dispose() {
+        super.dispose()
+        thumbnail.dispose()
+    }
+
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorModelAsset.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorModelAsset.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.editor.assets
+
+import com.badlogic.gdx.files.FileHandle
+import com.badlogic.gdx.graphics.Texture
+import com.mbrlabs.mundus.commons.assets.ModelAsset
+import com.mbrlabs.mundus.commons.assets.meta.Meta
+import com.mbrlabs.mundus.commons.utils.TextureProvider
+
+class EditorModelAsset(meta: Meta, assetFile: FileHandle) : ModelAsset(meta, assetFile), TextureProvider {
+
+    lateinit var thumbnail: Texture
+    override fun getTexture(): Texture = thumbnail
+
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/assets/AssetsDock.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/assets/AssetsDock.kt
@@ -38,7 +38,9 @@ import com.kotcrab.vis.ui.layout.GridGroup
 import com.kotcrab.vis.ui.widget.*
 import com.kotcrab.vis.ui.widget.tabbedpane.Tab
 import com.mbrlabs.mundus.commons.assets.*
+import com.mbrlabs.mundus.commons.utils.TextureProvider
 import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.assets.EditorModelAsset
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.*
 import com.mbrlabs.mundus.editor.ui.UI
@@ -312,7 +314,7 @@ class AssetsDock : Tab(false, false),
         }
 
         private fun loadBackground() {
-            if (asset is TextureAsset) {
+            if (asset is TextureProvider) {
                 nameTable.background = thumbnailOverlay
                 stack.add(Image(asset.texture))
             }

--- a/editor/src/main/com/mbrlabs/mundus/editor/utils/ThumbnailGenerator.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/utils/ThumbnailGenerator.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2023. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.editor.utils
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.graphics.GL30
+import com.badlogic.gdx.graphics.PerspectiveCamera
+import com.badlogic.gdx.graphics.Pixmap
+import com.badlogic.gdx.graphics.Texture
+import com.badlogic.gdx.graphics.g3d.Environment
+import com.badlogic.gdx.graphics.g3d.Model
+import com.badlogic.gdx.graphics.g3d.ModelBatch
+import com.badlogic.gdx.graphics.g3d.ModelInstance
+import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute
+import com.badlogic.gdx.graphics.glutils.GLFrameBuffer
+import com.badlogic.gdx.math.MathUtils
+import com.badlogic.gdx.math.MathUtils.tan
+import com.badlogic.gdx.math.Vector3
+import com.badlogic.gdx.math.collision.BoundingBox
+import com.badlogic.gdx.utils.ScreenUtils
+import com.mbrlabs.mundus.commons.shadows.MundusDirectionalShadowLight
+import com.mbrlabs.mundus.commons.utils.LightUtils
+import com.mbrlabs.mundus.commons.utils.ModelUtils
+import net.mgsx.gltf.scene3d.attributes.PBRCubemapAttribute
+import net.mgsx.gltf.scene3d.attributes.PBRTextureAttribute
+import net.mgsx.gltf.scene3d.shaders.PBRShaderConfig
+import net.mgsx.gltf.scene3d.shaders.PBRShaderProvider
+import net.mgsx.gltf.scene3d.utils.IBLBuilder
+
+object ThumbnailGenerator {
+
+    private const val THUMBNAIL_WIDTH = 100f
+    private const val THUMBNAIL_HEIGHT = 100f
+    private val BACKGROUND_COLOR = Colors.GRAY_888
+
+    fun generateThumbnail(model: Model): Texture {
+        val config = PBRShaderConfig()
+        config.numDirectionalLights = 1
+        config.numBones = ModelUtils.getBoneCount(model)
+        config.vertexShader = Gdx.files.internal("com/mbrlabs/mundus/commons/shaders/custom-gdx-pbr.vs.glsl").readString()
+        config.fragmentShader = Gdx.files.internal("com/mbrlabs/mundus/commons/shaders/custom-gdx-pbr.fs.glsl").readString()
+
+        val cam = PerspectiveCamera(67f, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT)
+        val modelBatch = ModelBatch(PBRShaderProvider(config))
+
+        val bounds = BoundingBox()
+        val modelInstance = ModelInstance(model)
+        modelInstance.calculateBoundingBox(bounds)
+
+        val center = Vector3()
+        val dimensions = Vector3()
+        bounds.getCenter(center)
+        bounds.getDimensions(dimensions)
+
+        val maxDimension = Math.max(dimensions.x, Math.max(dimensions.y, dimensions.z))
+        val distance =
+                (maxDimension / (2 * tan((cam.fieldOfView / 2 * MathUtils.degreesToRadians))))
+
+        var camFar = center.dst(bounds.getCorner000(Vector3())) + distance
+        camFar += 100f // Add additional buffer to distance
+
+        // Position up a bit, looking down at model
+        val verticalDistance = distance * 0.25f
+
+        cam.position.set(center.x + distance, center.y + verticalDistance, center.z + distance)
+        cam.lookAt(center)
+        cam.near = 0.1f
+        cam.far = camFar
+        cam.update()
+
+        val directionalLightEx = MundusDirectionalShadowLight()
+        directionalLightEx.intensity = LightUtils.DEFAULT_INTENSITY
+        directionalLightEx.setColor(LightUtils.DEFAULT_COLOR)
+        directionalLightEx.direction.set(-1f, -0.8f, -0.2f)
+
+        val iblBuilder = IBLBuilder.createOutdoor(directionalLightEx)
+//        val environmentCubemap = iblBuilder.buildEnvMap(1024)
+        val diffuseCubemap = iblBuilder.buildIrradianceMap(256)
+        val specularCubemap = iblBuilder.buildRadianceMap(10)
+        iblBuilder.dispose()
+
+        val env = Environment()
+
+        val brdfLUT = Texture(Gdx.files.classpath("net/mgsx/gltf/shaders/brdfLUT.png"))
+        env.set(ColorAttribute(ColorAttribute.AmbientLight, 1f, 1f, 1f, 1f))
+        env.set(PBRTextureAttribute(PBRTextureAttribute.BRDFLUTTexture, brdfLUT))
+        env.set(PBRCubemapAttribute.createSpecularEnv(specularCubemap))
+        env.set(PBRCubemapAttribute.createDiffuseEnv(diffuseCubemap))
+
+
+        val frameBufferBuilder = GLFrameBuffer.FrameBufferBuilder(THUMBNAIL_WIDTH.toInt(), THUMBNAIL_HEIGHT.toInt())
+        frameBufferBuilder.addBasicColorTextureAttachment(Pixmap.Format.RGBA8888)
+
+        // Enhanced precision, only needed for 3D scenes
+        frameBufferBuilder.addDepthRenderBuffer(GL30.GL_DEPTH_COMPONENT24)
+        val fbo = frameBufferBuilder.build()
+
+        fbo.begin()
+        ScreenUtils.clear(BACKGROUND_COLOR, true)
+        modelBatch.begin(cam)
+        modelBatch.render(modelInstance, env)
+        modelBatch.end()
+
+        val p = Pixmap.createFromFrameBuffer(0, 0, THUMBNAIL_WIDTH.toInt(), THUMBNAIL_HEIGHT.toInt())
+        // Flip the pixmap
+        val flipped = Pixmap(p.width, p.height, p.format)
+        for (x in 0 until p.width) {
+            for (y in 0 until p.height) {
+                flipped.drawPixel(x, p.height - 1 - y, p.getPixel(x, y))
+            }
+        }
+
+        fbo.end()
+
+        val thumbnail = Texture(flipped)
+
+        fbo.dispose()
+        p.dispose()
+        flipped.dispose()
+
+        return thumbnail
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/utils/ThumbnailGenerator.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/utils/ThumbnailGenerator.kt
@@ -88,7 +88,6 @@ object ThumbnailGenerator {
         directionalLightEx.direction.set(-1f, -0.8f, -0.2f)
 
         val iblBuilder = IBLBuilder.createOutdoor(directionalLightEx)
-//        val environmentCubemap = iblBuilder.buildEnvMap(1024)
         val diffuseCubemap = iblBuilder.buildIrradianceMap(256)
         val specularCubemap = iblBuilder.buildRadianceMap(10)
         iblBuilder.dispose()


### PR DESCRIPTION
Thumbnail visible for models in Assets Dock.

Creates thumbnail in these cases.
- Import 3D model into project
- Mundus editor startup

![image](https://github.com/JamesTKhan/Mundus/assets/1684274/a5478f14-2219-452b-83b5-baba0b0a9ed2)
