### PR TITLE
Doesn't generate LoD if it's checkbox is not enabled

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainChunksDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainChunksDialog.kt
@@ -346,15 +346,17 @@ class AddTerrainChunksDialog : BaseDialog("Add Terrain"), TabbedPaneListener {
             asset.updateTerrainMaterial()
             asset.terrain.update(ThreadLocalPools.vector3ThreadPool.get())
 
-            // Generate simplified results for LoD
-            val results = LoDUtils.buildTerrainLod(component, Terrain.LOD_SIMPLIFICATION_FACTORS, abs(maxHeight - minHeight))
-
             // post a Runnable to the rendering thread that processes the result
             Gdx.app.postRunnable {
                 component.updateDimensions()
 
-                // Convert to LodLevels with actual meshes
-                asset.lodLevels = LoDUtils.convertToLodLevels(asset.terrain.model, results)
+                if (generateLoD) {
+                    // Generate simplified results for LoD
+                    val results = LoDUtils.buildTerrainLod(component, Terrain.LOD_SIMPLIFICATION_FACTORS, abs(maxHeight - minHeight))
+
+                    // Convert to LodLevels with actual meshes
+                    asset.lodLevels = LoDUtils.convertToLodLevels(asset.terrain.model, results)
+                }
 
                 terraformingThreads.decrementAndGet()
             }


### PR DESCRIPTION
The dialog generates LoD for terrain if the checkbox is not selected.

![image](https://github.com/JamesTKhan/Mundus/assets/1684274/5c052b80-1d37-4d2e-b3e9-48538f6dcb98)
