### PR TITLE
Check shadow during frustum culling setting

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/CullableComponent.java
@@ -58,6 +58,7 @@ public abstract class CullableComponent extends AbstractComponent implements Mod
 
     // Is it offscreen?
     protected boolean isCulled = false;
+    private boolean checkShadowDuringFrustumCulling = true;
     private Array<Event> events;
     private ModelInstance modelInstance = null;
 
@@ -100,7 +101,7 @@ public abstract class CullableComponent extends AbstractComponent implements Mod
         visibleToPerspective = isVisible(sceneCam, modelInstance, center, radius);
 
         // If not visible to main cam, check if it's visible to shadow map (to prevent shadows popping out)
-        if (!visibleToPerspective) {
+        if (checkShadowDuringFrustumCulling && !visibleToPerspective) {
             if (gameObject.sceneGraph.scene.environment.shadowMap instanceof MundusDirectionalShadowLight) {
                 MundusDirectionalShadowLight shadowLight = (MundusDirectionalShadowLight) gameObject.sceneGraph.scene.environment.shadowMap;
                 visibleToShadowMap = isVisible(shadowLight.getCamera(), modelInstance, center, radius);
@@ -181,6 +182,14 @@ public abstract class CullableComponent extends AbstractComponent implements Mod
 
     public boolean isCulled() {
         return isCulled;
+    }
+
+    public boolean isCheckShadowDuringFrustumCulling() {
+        return checkShadowDuringFrustumCulling;
+    }
+
+    public void setCheckShadowDuringFrustumCulling(boolean checkShadowDuringFrustumCulling) {
+        this.checkShadowDuringFrustumCulling = checkShadowDuringFrustumCulling;
     }
 
     @Override

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -22,6 +22,7 @@
 - Sort children action command in Outline
 - Fix add water and terrain as child
 - Thumbnail view for model asset in Asset Dock
+- Add checkShadowDuringFrustumCulling setting into CullableComponent to disable/enable shadow checking during frustum culling
 
 [0.5.1] ~ 08/08/2023
 - Added FPS launcher argument, always call setForegroundFPS


### PR DESCRIPTION
Added `checkShadowDuringFrustumCulling` option into CullableComponent to enable/disable shadow checking during frustum culling.