### PR TITLE
Triplanar terrain fix for gdx-gltf upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
         mockitoVersion = '1.10.19'
         commonsIoVersion = '2.5'
         commonsLangVersion = '3.12.0'
-        gltfVersion = '7d70839'
+        gltfVersion = '2.2.1'
         args4jVersion = '2.33'
 
         ktxVersion = '1.12.0-rc1'

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/pbr/material.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/pbr/material.glsl
@@ -111,8 +111,7 @@ vec4 triplanar(sampler2D diffuseTexture, vec3 triblend, vec3 v_position)
 #define getColor nonTriplanar
 vec4 nonTriplanar(sampler2D diffuseTexture, vec2 coord, vec3 v_position)
 {
-    vec4 asd = texture2D(diffuseTexture, coord);
-    return asd;
+    return texture2D(diffuseTexture, coord);
 }
 #endif
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/pbr/material.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/pbr/material.glsl
@@ -87,7 +87,7 @@ uniform vec4 u_BaseColorFactor;
 // getColor == triplanar method
 #define getColor triplanar
 const float scaleAdjust = 0.01;
-vec4 triplanar(sampler2D diffuseTexture, vec3 triblend, vec3 v_position)
+vec4 triplanar(sampler2D diffuseTexture, vec3 triblend)
 {
 	vec2 uvX = v_position.zy * scaleAdjust;
 	vec2 uvY = v_position.xz * scaleAdjust;
@@ -108,11 +108,7 @@ vec4 triplanar(sampler2D diffuseTexture, vec3 triblend, vec3 v_position)
 }
 #else
 // getColor == texture2D method
-#define getColor nonTriplanar
-vec4 nonTriplanar(sampler2D diffuseTexture, vec2 coord, vec3 v_position)
-{
-    return texture2D(diffuseTexture, coord);
-}
+#define getColor texture2D
 #endif
 
 #ifdef diffuseTextureFlag
@@ -270,7 +266,7 @@ struct PBRSurfaceInfo
 #endif
 };
 
-vec4 getBaseColor(vec3 v_position)
+vec4 getBaseColor()
 {
     // The albedo may be defined from a base texture or a flat color
 #ifdef baseColorFactorFlag
@@ -289,28 +285,28 @@ vec4 getBaseColor(vec3 v_position)
     #else
     vec2 colorUv = vec2(0.0);
     #endif
-    #define getColor nonTriplanar
+    #define getColor texture2D
 #endif
 
 #ifdef diffuseTextureFlag
-    vec4 baseColor = getColor(u_diffuseTexture, colorUv, v_position);
+    vec4 baseColor = getColor(u_diffuseTexture, colorUv);
 
     #ifdef splatFlag
         splat = texture2D(u_texture_splat, v_splatPosition);
         #ifdef splatRFlag
-        vec4 colorR = getColor(u_texture_r, colorUv, v_position);
+        vec4 colorR = getColor(u_texture_r, colorUv);
         baseColor = mix(baseColor, mix(baseColor, colorR, splat.r), colorR.a);
         #endif
         #ifdef splatGFlag
-        vec4 colorG = getColor(u_texture_g, colorUv, v_position);
+        vec4 colorG = getColor(u_texture_g, colorUv);
         baseColor = mix(baseColor, mix(baseColor, colorG, splat.g), colorG.a);
         #endif
         #ifdef splatBFlag
-        vec4 colorB = getColor(u_texture_b, colorUv, v_position);
+        vec4 colorB = getColor(u_texture_b, colorUv);
         baseColor = mix(baseColor, mix(baseColor, colorB, splat.b), colorB.a);
         #endif
         #ifdef splatAFlag
-        vec4 colorA = getColor(u_texture_a, colorUv, v_position);
+        vec4 colorA = getColor(u_texture_a, colorUv);
         baseColor = mix(baseColor, mix(baseColor, colorA, splat.a), colorA.a);
         #endif
     #endif // splatFlag
@@ -341,21 +337,21 @@ vec3 getNormal()
         vec2 colorUv = v_diffuseUV;
     #endif
 
-    vec3 n = getColor(u_normalTexture, colorUv, v_position).rgb;
+    vec3 n = getColor(u_normalTexture, colorUv).rgb;
 
     #ifdef splatFlag
     vec3 splatNormal;
     #ifdef splatRNormalFlag
-        splatNormal += getColor(u_texture_r_normal, colorUv, v_position).rgb * splat.r;
+        splatNormal += getColor(u_texture_r_normal, colorUv).rgb * splat.r;
     #endif
     #ifdef splatGNormalFlag
-        splatNormal += getColor(u_texture_g_normal, colorUv, v_position).rgb * splat.g;
+        splatNormal += getColor(u_texture_g_normal, colorUv).rgb * splat.g;
     #endif
     #ifdef splatBNormalFlag
-        splatNormal += getColor(u_texture_b_normal, colorUv, v_position).rgb * splat.b;
+        splatNormal += getColor(u_texture_b_normal, colorUv).rgb * splat.b;
     #endif
     #ifdef splatANormalFlag
-        splatNormal += getColor(u_texture_a_normal, colorUv, v_position).rgb * splat.a;
+        splatNormal += getColor(u_texture_a_normal, colorUv).rgb * splat.a;
     #endif
     float normalBlendFactor = (1.0 - splat.r - splat.g - splat.b - splat.a);
     n = (n * normalBlendFactor) + splatNormal;

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/pbr/material.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/pbr/material.glsl
@@ -409,7 +409,7 @@ PBRSurfaceInfo getIridescenceInfo(PBRSurfaceInfo info){
 	info.iridescenceFactor *= texture2D(u_iridescenceSampler, v_iridescenceUV).r;
 #endif
 
-#ifdef iridescenceTextureFlag
+#ifdef iridescenceThicknessTextureFlag
 	float thicknessFactor = texture2D(u_iridescenceThicknessSampler, v_iridescenceThicknessUV).g;
 	info.iridescenceThickness = mix(u_iridescenceThicknessMin, u_iridescenceThicknessMax, thicknessFactor);
 #endif

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/pbr/pbr.fs.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/pbr/pbr.fs.glsl
@@ -5,8 +5,8 @@
 #ifdef iridescenceFlag
 #include <iridescence.glsl>
 #endif
-#include <material.glsl>
 #include <env.glsl>
+#include <material.glsl>
 #ifndef unlitFlag
 #include <lights.glsl>
 #include <shadows.glsl>
@@ -23,7 +23,7 @@ void main() {
     if ( v_clipDistance < 0.0 )
         discard;
 
-	vec4 baseColor = getBaseColor(v_position);
+	vec4 baseColor = getBaseColor();
     
     vec3 color = baseColor.rgb;
 
@@ -71,7 +71,7 @@ void main() {
     // convert to material roughness by squaring the perceptual roughness [2].
     float alphaRoughness = perceptualRoughness * perceptualRoughness;
 
-    vec4 baseColor = getBaseColor(v_position);
+    vec4 baseColor = getBaseColor();
 
 #ifdef iorFlag
     vec3 f0 = vec3(pow(( u_ior - 1.0) /  (u_ior + 1.0), 2.0));

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/pbr/pbr.fs.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/pbr/pbr.fs.glsl
@@ -23,7 +23,7 @@ void main() {
     if ( v_clipDistance < 0.0 )
         discard;
 
-	vec4 baseColor = getBaseColor();
+	vec4 baseColor = getBaseColor(v_position);
     
     vec3 color = baseColor.rgb;
 
@@ -71,8 +71,8 @@ void main() {
     // convert to material roughness by squaring the perceptual roughness [2].
     float alphaRoughness = perceptualRoughness * perceptualRoughness;
 
-    vec4 baseColor = getBaseColor();
-    
+    vec4 baseColor = getBaseColor(v_position);
+
 #ifdef iorFlag
     vec3 f0 = vec3(pow(( u_ior - 1.0) /  (u_ior + 1.0), 2.0));
 #else

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -22,7 +22,7 @@
 - Sort children action command in Outline
 - Fix add water and terrain as child
 - Thumbnail view for model asset in Asset Dock
-- Update gdx-gltf version to latest 7d70839067
+- Update gdx-gltf version to 2.2.1
 
 [0.5.1] ~ 08/08/2023
 - Added FPS launcher argument, always call setForegroundFPS

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -8,7 +8,7 @@
 - Add 'addGameObject(GameObject, ModelInstance, Vector3)' and 'addGameObject(GameObject, Model, Vector3)' methods to SceneGraph to add external model to scene graph where can add parent game object
 - Generic findComponentsByType and findComponentByType methods
 - Fix render water if it is child game object
-- Update gdx-gltf version to latest 7d70839067
+- Update gdx-gltf version to 2.2.1
 
 [0.5.1] ~ 08/08/2023
 - Updated libGDX to 1.12.0


### PR DESCRIPTION
The triplanar fix for gdx-gltf upgrade PR. 

This is the exception if I use triplanar terrain with gdx-gltf-upgrade branch:
```
[11:29][Trace][Outline] Project changed. Building scene graph.
[11:29][Fatal][Log] com.badlogic.gdx.utils.GdxRuntimeException: Shader compilation failed:
Fragment shader:
0:385(13): error: v_position' undeclared
0:385(13): error: type mismatch
0:385(13): error: operands to arithmetic operators must be numeric
0:386(13): error: v_position' undeclared
0:386(13): error: type mismatch
0:386(13): error: operands to arithmetic operators must be numeric
0:387(13): error: v_position' undeclared
0:387(13): error: type mismatch
0:387(13): error: operands to arithmetic operators must be numeric
0:390(37): warning: uvX' used uninitialized
0:391(37): warning: uvY' used uninitialized
0:392(37): warning: uvZ' used uninitialized

    at net.mgsx.gltf.scene3d.shaders.PBRShaderProvider.checkShaderCompilation(PBRShaderProvider.java:516)
    at net.mgsx.gltf.scene3d.shaders.PBRShaderProvider.createShader(PBRShaderProvider.java:487)
    at com.mbrlabs.mundus.commons.shaders.MundusPBRShaderProvider.createShader(MundusPBRShaderProvider.java:29)
    at com.badlogic.gdx.graphics.g3d.utils.BaseShaderProvider.getShader(BaseShaderProvider.java:34)
```

In this fix I've added `v_position` as method parameter into `getColor`.

Plus I've upgraded gdx-gltf version to 2.2.1, because the jitpack doesn't find the current (7d70839) revision in its repo.
I've used this changes: https://github.com/mgsx-dev/gdx-gltf/compare/7d70839067...2.2.1 and I've updated only `material.glsl` with `iridescenceThicknessTextureFlag` flag.