### PR TITLE
Update libGDX to 1.13.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
 
     ext {
         appName = "Mundus"
-        gdxVersion = '1.12.0'
+        gdxVersion = '1.13.0'
         visuiVersion = '1.5.2'
         kryoVersion = '5.2.0'
         junitVersion = '4.13.2'

--- a/editor/src/main/com/mbrlabs/mundus/editor/Main.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Main.kt
@@ -20,6 +20,7 @@ package com.mbrlabs.mundus.editor
 
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration
+import com.badlogic.gdx.utils.Os
 import com.badlogic.gdx.utils.SharedLibraryLoader
 import com.kotcrab.vis.ui.util.OsUtils
 import com.mbrlabs.mundus.commons.utils.ShaderPreprocessor
@@ -92,7 +93,7 @@ private fun launchEditor(options: LaunchOptions) {
     config.setForegroundFPS(options.fps)
 
     if (options.useGL30) {
-        if (SharedLibraryLoader.isMac) {
+        if (SharedLibraryLoader.os == Os.MacOsX ) {
             config.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.GL30, 3, 2)
         } else {
             config.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.GL30, 4, 3)

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/gizmos/LightGizmo.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/gizmos/LightGizmo.kt
@@ -11,7 +11,7 @@ import com.mbrlabs.mundus.commons.scene3d.components.LightComponent
  * @version June 01, 2022
  */
 class LightGizmo(private var lightComponent: LightComponent) : Gizmo() {
-    override lateinit var decal: Decal
+    override var decal: Decal
 
     init {
         val region = TextureRegion(Texture(Gdx.files.internal("icon/gizmos/lightbulb-icon.png")))


### PR DESCRIPTION
I've updated the libGDX to 1.13.0.

- The `SharedLibraryLoader.isMac` is deprecated, so I've changed to `SharedLibraryLoader.os == Os.MacOsX`, apidoc says this.
- I've removed the unnecessary `lateinit` keyword in LightGizmo class.

Now there is no warning message during building.