### PR TITLE
Source compatibility to 1.8

### DIFF
--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -4,8 +4,8 @@ apply plugin: "maven-publish"
 group = 'com.github.jamestkhan.mundus'
 version = '0.5.1'
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 sourceSets.main.java.srcDirs = ["src/main"]

--- a/editor-commons/build.gradle
+++ b/editor-commons/build.gradle
@@ -4,8 +4,8 @@ apply plugin: "maven-publish"
 group = 'com.github.jamestkhan.mundus'
 version = '0.5.1'
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 sourceSets.main.java.srcDirs = ["src/"]

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -9,6 +9,7 @@
 - Generic findComponentsByType and findComponentByType methods
 - Fix render water if it is child game object
 - Update gdx-gltf version to 2.2.1
+- Set source compatibility to 1.8
 
 [0.5.1] ~ 08/08/2023
 - Updated libGDX to 1.12.0

--- a/gdx-runtime/build.gradle
+++ b/gdx-runtime/build.gradle
@@ -4,8 +4,8 @@ apply plugin: "maven-publish"
 group = 'com.github.jamestkhan.mundus'
 version = '0.5.1'
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 sourceSets.main.java.srcDirs = ["src/"]
 sourceSets.main.resources.srcDirs = ["src/"]

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -4,8 +4,8 @@ apply plugin: "maven-publish"
 group = 'com.github.jamestkhan.mundus'
 version = '0.5.1'
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 sourceSets.main.java.srcDirs = ["src/"]


### PR DESCRIPTION
Hi,

I think we can increase source compatibility to 1.8. The default method feature in plugin api would be useful. 

The libGDX [wiki page](https://libgdx.com/wiki/articles/java-development-kit-selection#versions) says the 1.8 jdk version useable on all platfom, only the android 5/6 support will drop, but these are very [old android versions](https://en.wikipedia.org/wiki/Android_version_history).